### PR TITLE
feat: add YAML frontmatter to all documentation files (#10)

### DIFF
--- a/docs/01_overview/governance.md
+++ b/docs/01_overview/governance.md
@@ -1,5 +1,14 @@
+---
+title: "Governance Model"
+description: "Repository governance including GitFlow branching, PR requirements, and change management"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [governance, gitflow, branching, pr-process, change-management]
+category: "Overview"
+status: "in-progress"
+version: "1.0.0"
+---
 
-# Governance
 
 - Branching: Strict GitFlow with protected branches.
 - PRs: Required checks include linters, formatters, unit/integration tests, and metadata validation.

--- a/docs/01_overview/principles.md
+++ b/docs/01_overview/principles.md
@@ -1,5 +1,14 @@
+---
+title: "Core Principles"
+description: "Foundational principles governing the style guide: automation, AI-friendly metadata, and semantic versioning"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [principles, foundations, automation, metadata, standards]
+category: "Overview"
+status: "in-progress"
+version: "1.0.0"
+---
 
-# Principles
 
 - Strict, automatable formatting across repo with pre-commit and CI enforcement.
 - AI-friendly metadata (inline comment tags) for modules and scripts.

--- a/docs/01_overview/structure.md
+++ b/docs/01_overview/structure.md
@@ -1,5 +1,14 @@
+---
+title: "Repository Structure"
+description: "Repository layout and organization patterns for style guide implementation"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [structure, organization, repository-layout, monorepo, multi-repo]
+category: "Overview"
+status: "needs-update"
+version: "1.0.0"
+---
 
-# Structure
 
 Repository layout is split per guide (multi-repo). Each guide follows the
 structure:

--- a/docs/02_language_guides/ansible.md
+++ b/docs/02_language_guides/ansible.md
@@ -1,4 +1,14 @@
-# Ansible Style Guide
+---
+title: "Ansible Style Guide"
+description: "Configuration management standards for Ansible playbooks and roles"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [ansible, configuration-management, automation, devops, collections]
+category: "Language Guides"
+status: "needs-expansion"
+version: "0.1.0"
+---
+
 
 - Roles in `roles/<role_name>/` with `defaults`, `vars`, `tasks`, `handlers`, `meta`.
 - Use `ansible-lint` and `molecule` for testing.

--- a/docs/02_language_guides/bash.md
+++ b/docs/02_language_guides/bash.md
@@ -1,4 +1,14 @@
-# Bash Style Guide
+---
+title: "Bash Scripting Style Guide"
+description: "POSIX-compliant shell scripting standards for automation and DevOps"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [bash, shell, scripting, posix, automation]
+category: "Language Guides"
+status: "needs-expansion"
+version: "0.1.0"
+---
+
 
 - Use set -o errexit -o nounset -o pipefail and `shellcheck`.
 - Provide metadata header and `--help`.

--- a/docs/02_language_guides/jenkins_groovy.md
+++ b/docs/02_language_guides/jenkins_groovy.md
@@ -1,4 +1,14 @@
-# Jenkins / Groovy Style Guide
+---
+title: "Jenkins & Groovy Style Guide"
+description: "Jenkins declarative and scripted pipeline standards"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [jenkins, groovy, cicd, pipelines, automation]
+category: "Language Guides"
+status: "needs-creation"
+version: "0.1.0"
+---
+
 
 - Prefer declarative pipelines, shared libraries, and consistent stage naming.
 - Use strict error handling and post blocks for cleanup.

--- a/docs/02_language_guides/kubernetes.md
+++ b/docs/02_language_guides/kubernetes.md
@@ -1,4 +1,14 @@
-# Kubernetes & Helm Style Guide
+---
+title: "Kubernetes & Helm Style Guide"
+description: "Container orchestration standards for Kubernetes manifests and Helm charts"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [kubernetes, helm, containers, orchestration, k8s]
+category: "Language Guides"
+status: "needs-creation"
+version: "0.1.0"
+---
+
 
 - Strict naming, labels, annotations; validate manifests with `kubeval`/`kubectl --dry-run`.
 - Templates should be linted with `helm lint` and schema-validated.

--- a/docs/02_language_guides/powershell.md
+++ b/docs/02_language_guides/powershell.md
@@ -1,4 +1,14 @@
-# PowerShell Style Guide
+---
+title: "PowerShell Style Guide"
+description: "Cross-platform PowerShell 7+ scripting standards for automation"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [powershell, scripting, cross-platform, automation, windows]
+category: "Language Guides"
+status: "needs-creation"
+version: "0.1.0"
+---
+
 
 - Follow Microsoft-approved verbs and parameter conventions.
 - Enforce PSScriptAnalyzer in CI.

--- a/docs/02_language_guides/python.md
+++ b/docs/02_language_guides/python.md
@@ -1,4 +1,14 @@
-# Python Style Guide
+---
+title: "Python Style Guide"
+description: "Python coding standards for DevOps and infrastructure automation"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [python, programming, devops, automation, testing]
+category: "Language Guides"
+status: "needs-expansion"
+version: "0.1.0"
+---
+
 
 - Strict PEP8 + type hints.
 - Use `black`, `isort`, `flake8`, and `mypy` in pre-commit and CI.

--- a/docs/02_language_guides/sql.md
+++ b/docs/02_language_guides/sql.md
@@ -1,4 +1,14 @@
-# SQL Style Guide
+---
+title: "SQL Style Guide"
+description: "Database-agnostic SQL standards for queries, schemas, and migrations"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [sql, database, queries, data, standards]
+category: "Language Guides"
+status: "needs-expansion"
+version: "0.1.0"
+---
+
 
 - Use lowercase keywords and snake_case identifiers (your preference).
 - Include comments for complex queries and use parameterized statements.

--- a/docs/02_language_guides/terraform.md
+++ b/docs/02_language_guides/terraform.md
@@ -1,4 +1,14 @@
-# Terraform Style Guide (with Terragrunt)
+---
+title: "Terraform Style Guide"
+description: "Infrastructure as Code standards for Terraform modules and configurations"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [terraform, iac, infrastructure-as-code, hashicorp, devops]
+category: "Language Guides"
+status: "needs-expansion"
+version: "0.1.0"
+---
+
 
 - Use `snake_case` for variables, `kebab-case` for module directories.
 - Always run `terraform fmt -recursive`, `tflint`, and `terraform validate` in CI.

--- a/docs/02_language_guides/terragrunt.md
+++ b/docs/02_language_guides/terragrunt.md
@@ -1,4 +1,14 @@
-# Terragrunt Style Guide
+---
+title: "Terragrunt Style Guide"
+description: "Terragrunt wrapper standards for DRY Terraform configurations"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [terragrunt, terraform, iac, dry, devops]
+category: "Language Guides"
+status: "needs-expansion"
+version: "0.1.0"
+---
+
 
 - Use `live/<env>/<region>/<stack>/terragrunt.hcl` pattern.
 - Centralize remote state in top-level `terragrunt.hcl`.

--- a/docs/02_language_guides/typescript.md
+++ b/docs/02_language_guides/typescript.md
@@ -1,4 +1,14 @@
-# TypeScript Style Guide
+---
+title: "TypeScript Style Guide"
+description: "TypeScript coding standards for React, Next.js, and Node.js applications"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [typescript, javascript, react, nextjs, nodejs]
+category: "Language Guides"
+status: "needs-expansion"
+version: "0.1.0"
+---
+
 
 - Strict ESLint + Prettier + full type safety.
 - Use `tsconfig.json` with `strict: true`.

--- a/docs/02_language_guides/yaml_json_docker.md
+++ b/docs/02_language_guides/yaml_json_docker.md
@@ -1,4 +1,14 @@
-# YAML, JSON, Dockerfile Style Guide
+---
+title: "YAML, JSON, and Dockerfile Style Guide"
+description: "Configuration file and container standards (to be split into separate guides)"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [yaml, json, dockerfile, docker, configuration]
+category: "Language Guides"
+status: "needs-refactoring"
+version: "0.1.0"
+---
+
 
 - YAML: strict linting with `yamllint` and schema validation where applicable.
 - JSON: consistent 2-space indent; optional schema validation.

--- a/docs/03_metadata_schema/schema_reference.md
+++ b/docs/03_metadata_schema/schema_reference.md
@@ -1,5 +1,15 @@
+---
+title: "Metadata Schema Reference"
+description: "Comprehensive metadata tag schema for code annotations and AI integration"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [metadata, schema, annotations, ai, validation]
+category: "Metadata Schema"
+status: "needs-expansion"
+version: "0.1.0"
+---
 
-# Metadata Schema Reference
+
 
 Metadata is embedded inline as comment-based tags. Use language-appropriate comment syntax.
 

--- a/docs/04_templates/README_template.md
+++ b/docs/04_templates/README_template.md
@@ -1,5 +1,15 @@
+---
+title: "README Template"
+description: "Standard README template for modules and packages"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [template, readme, documentation, standards]
+category: "Templates"
+status: "active"
+version: "0.1.0"
+---
 
-# Module README Template
+
 
 ## Purpose
 

--- a/docs/05_ci_cd/ai_validation_pipeline.md
+++ b/docs/05_ci_cd/ai_validation_pipeline.md
@@ -1,5 +1,15 @@
+---
+title: "AI Validation Pipeline"
+description: "AI-powered validation pipeline for automated code review and style checking"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [cicd, ai, validation, automation, pipeline]
+category: "CI/CD"
+status: "needs-expansion"
+version: "0.1.0"
+---
 
-# CI / AI Validation Pipeline
+
 
 - Steps:
   1. Checkout

--- a/docs/06_container/usage.md
+++ b/docs/06_container/usage.md
@@ -1,4 +1,14 @@
-# Container Usage Guide
+---
+title: "Container Usage Guide"
+description: "Containerized validation tools and integration patterns"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [docker, containers, validation, cicd, integration]
+category: "Container"
+status: "active"
+version: "0.1.0"
+---
+
 
 The Coding Style Guide Validator is available as a containerized tool, making it easy to
 integrate validation into any repository without installing dependencies locally.

--- a/docs/07_integration/integration_prompt.md
+++ b/docs/07_integration/integration_prompt.md
@@ -1,4 +1,14 @@
-# Integration Prompt for Other Repositories
+---
+title: "Integration Guide"
+description: "Guide for integrating style standards with AI assistants and development workflows"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [integration, ai, claude, workflow, automation]
+category: "Integration"
+status: "active"
+version: "0.1.0"
+---
+
 
 Use this prompt to quickly integrate the coding style guide validator into any codebase.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
-# Changelog
+---
+title: "Changelog"
+description: "Project changelog tracking all notable changes"
+author: "Tyler Dukes"
+date: "2025-10-28"
+tags: [changelog, history, releases, versions]
+category: "Project"
+status: "needs-content"
+version: "0.1.0"
+---
+
 
 All releases follow semantic versioning. See tags for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,14 @@
-# The Dukes Engineering Style Guide
+---
+title: "The Dukes Engineering Style Guide"
+description: "Unified, opinionated standards for infrastructure and application code that is both human-readable and AI-optimized"
+author: "Tyler Dukes"
+date: "2025-10-27"
+tags: [style-guide, devops, infrastructure-as-code, best-practices, ai-optimized]
+category: "Home"
+status: "active"
+version: "1.0.0"
+---
+
 
 **Version:** 1.0.0
 **Maintainer:** Tyler Dukes


### PR DESCRIPTION
## Summary
- Added comprehensive YAML frontmatter to all 21 documentation files
- Removed duplicate H1 headings (MkDocs Material uses frontmatter titles)
- Verified MkDocs builds successfully with `--strict` flag

## Changes
### Frontmatter Added
Each file now includes:
- `title`: Page title (used by MkDocs Material)
- `description`: Page description for search and metadata
- `author`: "Tyler Dukes"
- `date`: "2025-10-28"
- `tags`: Relevant keywords for categorization
- `category`: Navigation grouping
- `status`: Document status (active, in-progress, needs-expansion, etc.)
- `version`: Semantic version

### Files Updated (21 total)
- docs/index.md
- docs/01_overview/*.md (3 files)
- docs/02_language_guides/*.md (12 files)
- docs/03_metadata_schema/schema_reference.md
- docs/04_templates/README_template.md
- docs/05_ci_cd/ai_validation_pipeline.md
- docs/06_container/usage.md
- docs/07_integration/integration_prompt.md
- docs/changelog.md

### Markdown Cleanup
- Removed first H1 heading from each file (after frontmatter ends)
- Prevents MD025 markdownlint error (multiple H1 headings)
- MkDocs Material automatically generates page title from frontmatter

## Testing
- ✅ MkDocs builds successfully: `uv run mkdocs build --strict`
- ✅ Pre-commit hooks pass (markdownlint, yamllint, etc.)

## Related Issues
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)