### PR TITLE
fix: update homepage version to 1.2.0 and remove hardcoded metadata

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,19 +2,11 @@
 title: "The Dukes Engineering Style Guide"
 description: "Unified, opinionated standards for infrastructure and application code that is both human-readable and AI-optimized"
 author: "Tyler Dukes"
-date: "2025-10-27"
+date: "2025-11-30"
 tags: [style-guide, devops, infrastructure-as-code, best-practices, ai-optimized]
 category: "Home"
 status: "active"
-version: "1.0.0"
----
-
-
-**Version:** 1.0.0
-**Maintainer:** Tyler Dukes
-**License:** MIT
-**Last Updated:** 2025-10-27
-
+version: "1.2.0"
 ---
 
 ## Introduction


### PR DESCRIPTION
## Description

Updates the homepage to fix version inconsistency and remove redundant hardcoded metadata.

## Changes

### Updated File
- **docs/index.md**:
  - Updated frontmatter version from 1.0.0 to 1.2.0 (now matches pyproject.toml)
  - Updated frontmatter date from 2025-10-27 to 2025-11-30 (current date)
  - Removed hardcoded metadata section (Version/Maintainer/License/Last Updated)

## Rationale

### Version Inconsistency
- Homepage displayed version 1.0.0
- pyproject.toml shows version 1.2.0
- Updated homepage to match the project version

### Removed Redundant Metadata
The hardcoded section displayed:
```
**Version:** 1.0.0
**Maintainer:** Tyler Dukes
**License:** MIT
**Last Updated:** 2025-10-27
```

This is redundant because:
- Version is already in frontmatter metadata
- Maintainer/Author is in frontmatter metadata
- License is in the LICENSE file
- Last Updated requires manual maintenance and creates inconsistency
- Frontmatter metadata is machine-readable and used by MkDocs

## Validation

- ✅ MkDocs build passes with strict mode (1.51s)
- ✅ All markdownlint checks pass
- ✅ Version now matches pyproject.toml
- ✅ Frontmatter metadata is current and accurate