### PR TITLE
feat: reorganize language guides by category in navigation (#66)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,25 +43,32 @@ nav:
       - Governance: 01_overview/governance.md
       - Structure: 01_overview/structure.md
   - Language Guides:
-      - Terraform & Terragrunt: 02_language_guides/terraform.md
-      - Terragrunt (live): 02_language_guides/terragrunt.md
-      - HCL: 02_language_guides/hcl.md
-      - Ansible: 02_language_guides/ansible.md
-      - Python: 02_language_guides/python.md
-      - TypeScript: 02_language_guides/typescript.md
-      - Bash: 02_language_guides/bash.md
-      - PowerShell: 02_language_guides/powershell.md
-      - Jenkins / Groovy: 02_language_guides/jenkins_groovy.md
-      - SQL: 02_language_guides/sql.md
-      - YAML: 02_language_guides/yaml.md
-      - JSON: 02_language_guides/json.md
-      - Dockerfile: 02_language_guides/dockerfile.md
-      - GitHub Actions: 02_language_guides/github_actions.md
-      - Makefile: 02_language_guides/makefile.md
-      - Docker Compose: 02_language_guides/docker_compose.md
-      - GitLab CI/CD: 02_language_guides/gitlab_ci.md
-      - AWS CDK: 02_language_guides/cdk.md
-      - Kubernetes & Helm: 02_language_guides/kubernetes.md
+      - Infrastructure as Code:
+          - Terraform & Terragrunt: 02_language_guides/terraform.md
+          - Terragrunt (live): 02_language_guides/terragrunt.md
+          - HCL: 02_language_guides/hcl.md
+          - AWS CDK: 02_language_guides/cdk.md
+          - Kubernetes & Helm: 02_language_guides/kubernetes.md
+      - Configuration Management:
+          - Ansible: 02_language_guides/ansible.md
+      - Programming Languages:
+          - Python: 02_language_guides/python.md
+          - TypeScript: 02_language_guides/typescript.md
+          - Bash: 02_language_guides/bash.md
+          - PowerShell: 02_language_guides/powershell.md
+          - SQL: 02_language_guides/sql.md
+      - CI/CD & Automation:
+          - Jenkins / Groovy: 02_language_guides/jenkins_groovy.md
+          - GitHub Actions: 02_language_guides/github_actions.md
+          - GitLab CI/CD: 02_language_guides/gitlab_ci.md
+      - Data Formats:
+          - YAML: 02_language_guides/yaml.md
+          - JSON: 02_language_guides/json.md
+      - Containerization:
+          - Dockerfile: 02_language_guides/dockerfile.md
+          - Docker Compose: 02_language_guides/docker_compose.md
+      - Build Tools:
+          - Makefile: 02_language_guides/makefile.md
   - Metadata Schema: 03_metadata_schema/schema_reference.md
   - Templates:
       - README Template: 04_templates/README_template.md


### PR DESCRIPTION
## Summary

This PR reorganizes the language guides navigation from a flat list into logical categories for improved discoverability and user experience.

## Changes

### Navigation Structure

**Before**: Flat list of 19 language guides

**After**: Organized into 7 categories:

1. **Infrastructure as Code** (5 guides)
   - Terraform & Terragrunt
   - Terragrunt (live)
   - HCL
   - AWS CDK
   - Kubernetes & Helm

2. **Configuration Management** (1 guide)
   - Ansible

3. **Programming Languages** (5 guides)
   - Python
   - TypeScript
   - Bash
   - PowerShell
   - SQL

4. **CI/CD & Automation** (3 guides)
   - Jenkins / Groovy
   - GitHub Actions
   - GitLab CI/CD

5. **Data Formats** (2 guides)
   - YAML
   - JSON

6. **Containerization** (2 guides)
   - Dockerfile
   - Docker Compose

7. **Build Tools** (1 guide)
   - Makefile

### Benefits

- **Improved Discoverability**: Users can quickly find guides in their technology area
- **Logical Grouping**: Related technologies are grouped together
- **Better Organization**: Categories make sense from both DevOps and development perspectives
- **Scalability**: Easy to add new guides to existing categories

### File Modified

- `mkdocs.yml` - Updated navigation structure

## Testing

- ✅ `uv run mkdocs build --strict` - Passed
- ✅ Pre-commit hooks - All passed
- ✅ Navigation tested locally with `mkdocs serve`

## Related Issues

Implements #66

## Checklist

- [x] Navigation reorganized into logical categories
- [x] All existing guides remain accessible
- [x] MkDocs build passes
- [x] Pre-commit hooks pass
- [x] Tested navigation structure locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>