### PR TITLE
feat: add 'See Also' cross-reference sections - Phase 1 (#67)

### DIFF
--- a/docs/01_overview/getting_started.md
+++ b/docs/01_overview/getting_started.md
@@ -650,6 +650,46 @@ Found something missing or incorrect?
 2. Submit a pull request: [Contributing Guide](https://github.com/tydukes/coding-style-guide/blob/main/CONTRIBUTING.md)
 3. Join discussions: [GitHub Discussions](https://github.com/tydukes/coding-style-guide/discussions)
 
+## See Also
+
+### Core Documentation
+
+- [Principles](principles.md) - Style guide philosophy and core values
+- [Governance](governance.md) - Decision-making and contribution process
+- [Structure](structure.md) - Repository organization patterns
+- [Metadata Schema](../03_metadata_schema/schema_reference.md) - Frontmatter requirements
+
+### Popular Language Guides
+
+- [Python Style Guide](../02_language_guides/python.md) - Python development standards
+- [TypeScript Style Guide](../02_language_guides/typescript.md) - TypeScript development standards
+- [Terraform Style Guide](../02_language_guides/terraform.md) - Infrastructure as Code standards
+- [Bash Style Guide](../02_language_guides/bash.md) - Shell scripting standards
+
+### Development Setup
+
+- [IDE Integration Guide](../05_ci_cd/ide_integration_guide.md) - Editor setup for validation
+- [Pre-commit Hooks Guide](../05_ci_cd/precommit_hooks_guide.md) - Local validation hooks
+- [Local Validation Setup](../05_ci_cd/local_validation_setup.md) - Development environment
+
+### CI/CD Integration
+
+- [GitHub Actions Guide](../05_ci_cd/github_actions_guide.md) - GitHub workflow examples
+- [GitLab CI Guide](../05_ci_cd/gitlab_ci_guide.md) - GitLab pipeline examples
+- [Jenkins Pipeline Guide](../05_ci_cd/jenkins_pipeline_guide.md) - Jenkins configuration
+- [AI Validation Pipeline](../05_ci_cd/ai_validation_pipeline.md) - Automated code review
+
+### Templates & Examples
+
+- [README Template](../04_templates/README_template.md) - Project documentation
+- [Python Package Template](../04_templates/python_package_template.md) - Python project structure
+- [Terraform Module Template](../04_templates/terraform_module_template.md) - Terraform module structure
+
+### Container Usage
+
+- [Container Usage Guide](../06_container/usage.md) - Docker-based validation
+- [Integration Guide](../07_integration/integration_prompt.md) - Integrate into your projects
+
 ## Resources
 
 ### Documentation

--- a/docs/02_language_guides/python.md
+++ b/docs/02_language_guides/python.md
@@ -794,8 +794,37 @@ def get_user(
 - [mypy Type Checker](https://mypy.readthedocs.io/)
 - [pytest Testing Framework](https://docs.pytest.org/)
 
-### Related Guides
+### See Also
 
-- [Metadata Schema Reference](../03_metadata_schema/schema_reference.md)
-- [Getting Started Guide](../01_overview/getting_started.md)
-- [CI/CD Integration](../05_ci_cd/ai_validation_pipeline.md)
+### Related Language Guides
+
+- [TypeScript Style Guide](typescript.md) - Modern type-safe programming
+- [Bash Style Guide](bash.md) - Shell scripting for automation
+
+### Development Tools & Practices
+
+- [IDE Integration Guide](../05_ci_cd/ide_integration_guide.md) - VS Code, PyCharm setup
+- [Pre-commit Hooks Guide](../05_ci_cd/precommit_hooks_guide.md) - Automated validation
+- [Local Validation Setup](../05_ci_cd/local_validation_setup.md) - Development environment
+
+### Testing & Quality
+
+- [Testing Strategies](../05_ci_cd/testing_strategies.md) - pytest patterns and best practices
+- [Security Scanning Guide](../05_ci_cd/security_scanning_guide.md) - Bandit, Safety integration
+
+### CI/CD Integration
+
+- [GitHub Actions Guide](../05_ci_cd/github_actions_guide.md) - Python workflow examples
+- [GitLab CI Guide](../05_ci_cd/gitlab_ci_guide.md) - Pipeline configuration
+- [AI Validation Pipeline](../05_ci_cd/ai_validation_pipeline.md) - Automated code review
+
+### Templates & Examples
+
+- [Python Package Template](../04_templates/python_package_template.md) - Project structure
+- [Python Package Example](../05_examples/python_package_example.md) - Complete implementation
+
+### Core Documentation
+
+- [Getting Started Guide](../01_overview/getting_started.md) - Repository setup
+- [Metadata Schema Reference](../03_metadata_schema/schema_reference.md) - Frontmatter requirements
+- [Principles](../01_overview/principles.md) - Style guide philosophy

--- a/docs/02_language_guides/terraform.md
+++ b/docs/02_language_guides/terraform.md
@@ -1218,6 +1218,50 @@ output "internet_gateway_id" {
 
 ---
 
+## See Also
+
+### Related Infrastructure Guides
+
+- [HCL Style Guide](hcl.md) - HashiCorp Configuration Language fundamentals
+- [Terragrunt Guide](terragrunt.md) - DRY Terraform configurations
+- [AWS CDK Guide](cdk.md) - Alternative IaC with TypeScript/Python
+- [Kubernetes & Helm Guide](kubernetes.md) - Container orchestration IaC
+
+### Configuration Management
+
+- [Ansible Guide](ansible.md) - Configuration management and provisioning
+
+### Development Tools & Practices
+
+- [IDE Integration Guide](../05_ci_cd/ide_integration_guide.md) - VS Code, IntelliJ Terraform plugins
+- [Pre-commit Hooks Guide](../05_ci_cd/precommit_hooks_guide.md) - terraform fmt, validate, tflint
+- [Local Validation Setup](../05_ci_cd/local_validation_setup.md) - Terraform, tflint, checkov setup
+
+### Testing & Quality
+
+- [Testing Strategies](../05_ci_cd/testing_strategies.md) - Terratest, kitchen-terraform patterns
+- [Security Scanning Guide](../05_ci_cd/security_scanning_guide.md) - checkov, tfsec, terrascan
+
+### CI/CD Integration
+
+- [GitHub Actions Guide](../05_ci_cd/github_actions_guide.md) - Terraform workflow examples
+- [GitLab CI Guide](../05_ci_cd/gitlab_ci_guide.md) - Terraform pipeline configuration
+- [AI Validation Pipeline](../05_ci_cd/ai_validation_pipeline.md) - Automated IaC review
+
+### Templates & Examples
+
+- [Terraform Module Template](../04_templates/terraform_module_template.md) - Module structure
+- [Terraform Module Example](../05_examples/terraform_module_example.md) - Complete module
+
+### Core Documentation
+
+- [Getting Started Guide](../01_overview/getting_started.md) - Repository setup
+- [Metadata Schema Reference](../03_metadata_schema/schema_reference.md) - Frontmatter requirements
+- [Structure Guide](../01_overview/structure.md) - Terraform project organization
+- [Principles](../01_overview/principles.md) - Style guide philosophy
+
+---
+
 ## References
 
 ### Official Documentation

--- a/docs/02_language_guides/typescript.md
+++ b/docs/02_language_guides/typescript.md
@@ -953,6 +953,49 @@ if (!isUser(data)) {
 
 ---
 
+## See Also
+
+### Related Language Guides
+
+- [Python Style Guide](python.md) - Similar modern type-safe development
+- [JavaScript/JSON Guide](json.md) - JSON data structures and APIs
+- [Bash Style Guide](bash.md) - Build scripts and automation
+
+### Development Tools & Practices
+
+- [IDE Integration Guide](../05_ci_cd/ide_integration_guide.md) - VS Code, WebStorm setup
+- [Pre-commit Hooks Guide](../05_ci_cd/precommit_hooks_guide.md) - ESLint, Prettier automation
+- [Local Validation Setup](../05_ci_cd/local_validation_setup.md) - Node.js, npm/pnpm setup
+
+### Testing & Quality
+
+- [Testing Strategies](../05_ci_cd/testing_strategies.md) - Jest, Playwright, Cypress patterns
+- [Security Scanning Guide](../05_ci_cd/security_scanning_guide.md) - npm audit, Snyk integration
+
+### CI/CD Integration
+
+- [GitHub Actions Guide](../05_ci_cd/github_actions_guide.md) - Node.js workflow examples
+- [GitLab CI Guide](../05_ci_cd/gitlab_ci_guide.md) - TypeScript pipeline configuration
+- [AI Validation Pipeline](../05_ci_cd/ai_validation_pipeline.md) - Automated code review
+
+### Infrastructure & Deployment
+
+- [AWS CDK Guide](cdk.md) - Infrastructure as Code with TypeScript
+- [Dockerfile Guide](dockerfile.md) - Node.js containerization
+- [Docker Compose Guide](docker_compose.md) - Multi-container applications
+
+### Templates & Examples
+
+- [TypeScript Library Example](../05_examples/typescript_library_example.md) - Complete library setup
+
+### Core Documentation
+
+- [Getting Started Guide](../01_overview/getting_started.md) - Repository setup
+- [Metadata Schema Reference](../03_metadata_schema/schema_reference.md) - Frontmatter requirements
+- [Principles](../01_overview/principles.md) - Style guide philosophy
+
+---
+
 ## References
 
 ### Official Documentation

--- a/docs/05_ci_cd/github_actions_guide.md
+++ b/docs/05_ci_cd/github_actions_guide.md
@@ -1382,6 +1382,45 @@ jobs:
 
 ---
 
+## See Also
+
+### Related CI/CD Guides
+
+- [GitLab CI Guide](gitlab_ci_guide.md) - Alternative CI/CD platform
+- [Jenkins Pipeline Guide](jenkins_pipeline_guide.md) - Traditional CI/CD with Jenkins
+- [AI Validation Pipeline](ai_validation_pipeline.md) - Automated code review
+
+### Development Practices
+
+- [Pre-commit Hooks Guide](precommit_hooks_guide.md) - Local validation before commits
+- [Local Validation Setup](local_validation_setup.md) - Development environment setup
+- [IDE Integration Guide](ide_integration_guide.md) - Editor integration for validation
+
+### Testing & Security
+
+- [Testing Strategies](testing_strategies.md) - Test automation patterns
+- [Security Scanning Guide](security_scanning_guide.md) - SAST, SCA, secrets detection
+
+### Language-Specific Workflows
+
+- [Python Guide](../02_language_guides/python.md) - pytest, black, mypy workflows
+- [TypeScript Guide](../02_language_guides/typescript.md) - Jest, ESLint, Prettier workflows
+- [Terraform Guide](../02_language_guides/terraform.md) - terraform fmt, validate, plan workflows
+- [Docker Guide](../02_language_guides/dockerfile.md) - Container build and push workflows
+
+### Templates & Configuration
+
+- [GitHub Actions Workflow Templates](../04_templates/github_actions_workflow_templates.md) - Reusable workflows
+- [.gitignore Templates](../04_templates/gitignore_templates.md) - Ignore patterns
+
+### Core Documentation
+
+- [Getting Started Guide](../01_overview/getting_started.md) - Repository setup
+- [Principles](../01_overview/principles.md) - CI/CD philosophy
+- [Structure Guide](../01_overview/structure.md) - Project organization
+
+---
+
 ## References
 
 ### Official Documentation


### PR DESCRIPTION
## Summary

Adds comprehensive "See Also" cross-reference sections to 5 high-priority documentation pages (Phase 1 of #67).

## Changes

### Files Modified (5 pages)
1. `docs/02_language_guides/python.md`
2. `docs/02_language_guides/typescript.md`
3. `docs/02_language_guides/terraform.md`
4. `docs/05_ci_cd/github_actions_guide.md`
5. `docs/01_overview/getting_started.md`

### Pattern Established

Each "See Also" section includes organized subsections:
- **Related Language/Technology Guides** - Cross-references to similar or complementary guides
- **Development Tools & Practices** - IDE integration, pre-commit hooks, local validation
- **Testing & Quality** - Testing strategies and security scanning
- **CI/CD Integration** - Pipeline configuration and automation
- **Templates & Examples** - Reusable templates and complete examples
- **Core Documentation** - Getting started, principles, metadata schema

## Implementation Details

- Used proper markdown heading hierarchy (### for subsections)
- Relative links for internal documentation navigation
- Context-specific cross-references for each page type
- Fixed markdownlint MD036 errors (converted bold text to proper headings)

## Validation

- ✅ Pre-commit hooks passed (yamllint, markdownlint)
- ✅ MkDocs build successful (`uv run mkdocs build --strict`)
- ✅ All internal links verified

## Next Steps

Phase 1 establishes the pattern for cross-referencing. Remaining 48 pages can follow this template in subsequent PRs.

Closes #67 (partial - Phase 1 of multi-phase rollout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>