### PR TITLE
fix: resolve broken links in documentation (Closes #197)

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -383,6 +383,9 @@
     },
     {
       "pattern": "^https://img.shields.io"
+    },
+    {
+      "pattern": "^https://github.com/your-org"
     }
   ],
   "replacementPatterns": [

--- a/docs/01_overview/getting_started.md
+++ b/docs/01_overview/getting_started.md
@@ -2725,7 +2725,7 @@ After completing your scenario, here's your roadmap:
 
 - **Documentation Site**: [https://tydukes.github.io/coding-style-guide/](https://tydukes.github.io/coding-style-guide/)
 - **GitHub Repository**: [https://github.com/tydukes/coding-style-guide](https://github.com/tydukes/coding-style-guide)
-- **Container Registry**: [ghcr.io/tydukes/coding-style-guide](https://github.com/tydukes/coding-style-guide/pkgs/container/coding-style-guide)
+- **Container Registry**: `ghcr.io/tydukes/coding-style-guide`
 - **Issues**: [GitHub Issues](https://github.com/tydukes/coding-style-guide/issues)
 
 ### Quick Reference


### PR DESCRIPTION
## Summary

Fixes broken links detected by the link checker workflow in issue #197.

## Root Cause Analysis

The link checker workflow (run #20545690863) detected 2 broken links:

1. **Container Registry Link**: The documentation was linking to a GitHub packages URL that doesn't exist
2. **Placeholder Links**: Example code blocks contain intentional placeholder URLs with `your-org` that shouldn't be checked

## Changes

### 1. Fixed Container Registry Link (`docs/01_overview/getting_started.md`)

**Before**:
```markdown
- **Container Registry**: [ghcr.io/tydukes/coding-style-guide](https://github.com/tydukes/coding-style-guide/pkgs/container/coding-style-guide)
```

**After**:
```markdown
- **Container Registry**: `ghcr.io/tydukes/coding-style-guide`
```

**Rationale**:
- The GitHub packages URL (`/pkgs/container/coding-style-guide`) returns 404
- Container registries are accessed via `docker pull`, not web browsers
- Using code formatting instead of a link is more appropriate

### 2. Added Placeholder Link Exclusion (`.github/markdown-link-check-config.json`)

**Added pattern**:
```json
{
  "pattern": "^https://github.com/your-org"
}
```

**Rationale**:
- Documentation includes example code blocks with placeholder URLs
- These are intentional examples showing template usage
- Excluding them prevents false positives in link checking

## Testing

Verified with `markdown-link-check` that all links now pass:

```bash
# Test getting_started.md
npx markdown-link-check docs/01_overview/getting_started.md --config .github/markdown-link-check-config.json
# Result: 24 links checked ✅

# Test IDE settings template (previously reported issue)
npx markdown-link-check docs/04_templates/ide_settings_template.md --config .github/markdown-link-check-config.json
# Result: 16 links checked ✅
```

## Impact

- ✅ **Broken Link**: Container registry link fixed
- ✅ **False Positives**: Placeholder links excluded from checking
- ✅ **CI/CD**: Link checker workflow will now pass
- ✅ **No Breaking Changes**: Documentation content unchanged, only link formatting

## Related Context

**Note**: The original broken link mentioned in issue #197 (`pre_commit_hooks.md` → `precommit_hooks_guide.md`) was already fixed in commits `bd0cd36` and `2381e70` after the workflow ran against commit `ae85ef2`. This PR addresses the remaining broken links discovered during verification.

## Next Steps

After merge:
- Issue #197 will be automatically closed
- Link checker workflow should pass on next run
- No additional action required

---

**Ready for review and merge!**

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>