### PR TITLE
Update Dependabot Configuration for Community Contributions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,6 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
-    reviewers:
-      - "tydukes"
-    assignees:
-      - "tydukes"
     # Group minor and patch updates together
     groups:
       mkdocs:
@@ -49,10 +45,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    reviewers:
-      - "tydukes"
-    assignees:
-      - "tydukes"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
@@ -69,7 +61,3 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    reviewers:
-      - "tydukes"
-    assignees:
-      - "tydukes"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,6 +425,14 @@ priorities.
 - **Trigger**: Runs after `ci.yml` workflow succeeds
 - **Requirement**: `AUTO_MERGE_TOKEN` secret must be configured
 
+**Dependabot Workflow**:
+
+- Dependabot PRs are created without assigned reviewers or assignees
+- Community members can review and approve Dependabot PRs
+- Auto-merge automatically triggers after CI validation passes
+- No manual reviewer assignment needed
+- CI validation remains a blocking requirement for merge
+
 ### GitHub Workflows
 
 **ci.yml** (Main CI Pipeline):


### PR DESCRIPTION
## Summary

Removes assigned reviewers and assignees from Dependabot configuration to enable community-driven dependency management while maintaining auto-merge capabilities.

## Changes

- **`.github/dependabot.yml`**: Removed `reviewers` and `assignees` from all package ecosystems (pip, github-actions, docker)
- **`CLAUDE.md`**: Updated Auto-Merge Behavior section to document new Dependabot workflow

## Benefits

- Eliminates bottlenecks for dependency updates
- Enables community participation in reviewing Dependabot PRs
- Maintains quality through CI validation
- Leverages existing auto-merge automation

## Workflow After This Change

1. Dependabot creates PR without assigned reviewers/assignees
2. Community members can review and approve
3. CI validation runs (blocking requirement)
4. Auto-merge triggers after CI passes for `dependabot[bot]` PRs
5. Branch automatically deleted after merge

## Testing

- Auto-merge workflow verified to work unchanged (checks author is `dependabot[bot]` or `tydukes`)
- CI validation remains blocking requirement
- Will test with next Dependabot PR (scheduled weekly on Mondays)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)