### PR TITLE
fix(docs): correct broken SECURITY.md link in sonarcloud review guide

### DIFF
--- a/.sonarcloud-hotspot-review.md
+++ b/.sonarcloud-hotspot-review.md
@@ -45,11 +45,11 @@ and SHA pinning only for third-party actions with security concerns.
 
 Based on our workflow files, these are likely the hotspots:
 
-1. `.github/workflows/ci.yml` - actions/checkout@v6.0.1
-2. `.github/workflows/ci.yml` - actions/cache@v5
-3. `.github/workflows/ci.yml` - actions/upload-artifact@v6
-4. `.github/workflows/deploy.yml` - actions/checkout@v6
-5. `.github/workflows/container.yml` - docker/setup-buildx-action@v3
+1. `.github/workflows/ci.yml` - `actions/checkout@v6.0.1`
+2. `.github/workflows/ci.yml` - `actions/cache@v5`
+3. `.github/workflows/ci.yml` - `actions/upload-artifact@v6`
+4. `.github/workflows/deploy.yml` - `actions/checkout@v6`
+5. `.github/workflows/container.yml` - `docker/setup-buildx-action@v3`
 
 ### Why This is Safe
 
@@ -84,7 +84,7 @@ curl -u "${SONAR_TOKEN}:" -X POST \
 
 ### References
 
-- [SECURITY.md](../SECURITY.md) - Our GitHub Actions versioning policy
+- [SECURITY.md](./SECURITY.md) - Our GitHub Actions versioning policy
 - [SonarCloud Security Hotspots Docs](https://docs.sonarcloud.io/digging-deeper/security-hotspots/)
 - [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
 


### PR DESCRIPTION
## Summary

Fixed broken links in `.sonarcloud-hotspot-review.md` that were causing the link checker to fail:

- Changed `../SECURITY.md` to `./SECURITY.md` (both files are in the root directory)
- Wrapped GitHub Actions references in backticks to prevent the link checker from misinterpreting `@` symbols as email addresses

## Changes

- ✅ Fixed relative path to SECURITY.md (line 87)
- ✅ Added backticks around action references (lines 48-52)
- ✅ Verified all links pass with `npx markdown-link-check`

## Test Plan

- [x] Ran link checker locally on `.sonarcloud-hotspot-review.md` - all links pass
- [x] Verified SECURITY.md exists in the same directory
- [x] Pre-commit hooks passed

## Related Issues

Fixes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)