### PR TITLE
feat(templates): add reusable workflows and code generators templates

### DIFF
--- a/docs/04_templates/code_generators_template.md
+++ b/docs/04_templates/code_generators_template.md
@@ -1,0 +1,2232 @@
+---
+title: "Code Generator Templates"
+description: "Production-ready templates for Plop, Copier, and Yeoman code generators"
+author: "Tyler Dukes"
+tags: [code-generation, plop, copier, yeoman, scaffolding, automation]
+category: "Templates"
+status: "active"
+---
+<!-- markdownlint-disable MD013 MD024 -->
+
+## Overview
+
+This document provides comprehensive templates for code generation tools including Plop, Copier,
+and Yeoman. These generators enable consistent code scaffolding across projects, reducing
+boilerplate and enforcing best practices.
+
+---
+
+## Plop Generator Templates
+
+Plop is a micro-generator framework that makes it easy to create files with a consistent structure.
+
+### Project Setup
+
+```javascript
+// plopfile.js
+module.exports = function (plop) {
+  // Load all generators
+  plop.load('./plop/generators/component.js');
+  plop.load('./plop/generators/api-endpoint.js');
+  plop.load('./plop/generators/database-migration.js');
+  plop.load('./plop/generators/test.js');
+  plop.load('./plop/generators/hook.js');
+  plop.load('./plop/generators/service.js');
+
+  // Custom helpers
+  plop.setHelper('upperCase', (text) => text.toUpperCase());
+  plop.setHelper('lowerCase', (text) => text.toLowerCase());
+  plop.setHelper('camelCase', (text) => plop.getHelper('camelCase')(text));
+  plop.setHelper('pascalCase', (text) => plop.getHelper('pascalCase')(text));
+  plop.setHelper('kebabCase', (text) => plop.getHelper('kebabCase')(text));
+  plop.setHelper('snakeCase', (text) => plop.getHelper('snakeCase')(text));
+
+  // Date helpers
+  plop.setHelper('currentDate', () => new Date().toISOString().split('T')[0]);
+  plop.setHelper('currentYear', () => new Date().getFullYear().toString());
+
+  // Conditional helper
+  plop.setHelper('ifEquals', function (arg1, arg2, options) {
+    return arg1 === arg2 ? options.fn(this) : options.inverse(this);
+  });
+};
+```
+
+### React Component Generator
+
+```javascript
+// plop/generators/component.js
+module.exports = function (plop) {
+  plop.setGenerator('component', {
+    description: 'Create a React component',
+    prompts: [
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Component name:',
+        validate: (value) => {
+          if (!value) return 'Component name is required';
+          if (!/^[A-Z][a-zA-Z0-9]*$/.test(value)) {
+            return 'Component name must be PascalCase';
+          }
+          return true;
+        },
+      },
+      {
+        type: 'list',
+        name: 'type',
+        message: 'Component type:',
+        choices: [
+          { name: 'Functional Component', value: 'functional' },
+          { name: 'Page Component', value: 'page' },
+          { name: 'Layout Component', value: 'layout' },
+          { name: 'UI Component', value: 'ui' },
+        ],
+        default: 'functional',
+      },
+      {
+        type: 'confirm',
+        name: 'hasTests',
+        message: 'Include tests?',
+        default: true,
+      },
+      {
+        type: 'confirm',
+        name: 'hasStyles',
+        message: 'Include styles (CSS module)?',
+        default: true,
+      },
+      {
+        type: 'confirm',
+        name: 'hasStorybook',
+        message: 'Include Storybook story?',
+        default: true,
+      },
+    ],
+    actions: (data) => {
+      const basePath = data.type === 'page'
+        ? 'src/pages/{{pascalCase name}}'
+        : data.type === 'layout'
+          ? 'src/layouts/{{pascalCase name}}'
+          : data.type === 'ui'
+            ? 'src/components/ui/{{pascalCase name}}'
+            : 'src/components/{{pascalCase name}}';
+
+      const actions = [
+        {
+          type: 'add',
+          path: `${basePath}/{{pascalCase name}}.tsx`,
+          templateFile: 'plop/templates/component/component.tsx.hbs',
+        },
+        {
+          type: 'add',
+          path: `${basePath}/index.ts`,
+          templateFile: 'plop/templates/component/index.ts.hbs',
+        },
+      ];
+
+      if (data.hasStyles) {
+        actions.push({
+          type: 'add',
+          path: `${basePath}/{{pascalCase name}}.module.css`,
+          templateFile: 'plop/templates/component/styles.module.css.hbs',
+        });
+      }
+
+      if (data.hasTests) {
+        actions.push({
+          type: 'add',
+          path: `${basePath}/{{pascalCase name}}.test.tsx`,
+          templateFile: 'plop/templates/component/component.test.tsx.hbs',
+        });
+      }
+
+      if (data.hasStorybook) {
+        actions.push({
+          type: 'add',
+          path: `${basePath}/{{pascalCase name}}.stories.tsx`,
+          templateFile: 'plop/templates/component/component.stories.tsx.hbs',
+        });
+      }
+
+      return actions;
+    },
+  });
+};
+```
+
+### Component Templates
+
+```handlebars
+{{!-- plop/templates/component/component.tsx.hbs --}}
+import React from 'react';
+{{#if hasStyles}}
+import styles from './{{pascalCase name}}.module.css';
+{{/if}}
+
+export interface {{pascalCase name}}Props {
+  /** Optional className for styling */
+  className?: string;
+  /** Content to render */
+  children?: React.ReactNode;
+}
+
+/**
+ * {{pascalCase name}} component
+ *
+ * @example
+ * ```tsx
+ * <{{pascalCase name}}>
+ *   Content here
+ * </{{pascalCase name}}>
+ * ```
+ */
+export const {{pascalCase name}}: React.FC<{{pascalCase name}}Props> = ({
+  className,
+  children,
+}) => {
+  return (
+    <div
+      className={`{{#if hasStyles}}${styles.container}{{/if}}${className ? ` ${className}` : ''}`}
+      data-testid="{{kebabCase name}}"
+    >
+      {children}
+    </div>
+  );
+};
+
+{{pascalCase name}}.displayName = '{{pascalCase name}}';
+```
+
+```handlebars
+{{!-- plop/templates/component/component.test.tsx.hbs --}}
+import { render, screen } from '@testing-library/react';
+import { {{pascalCase name}} } from './{{pascalCase name}}';
+
+describe('{{pascalCase name}}', () => {
+  it('renders without crashing', () => {
+    render(<{{pascalCase name}} />);
+    expect(screen.getByTestId('{{kebabCase name}}')).toBeInTheDocument();
+  });
+
+  it('renders children correctly', () => {
+    render(<{{pascalCase name}}>Test content</{{pascalCase name}}>);
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<{{pascalCase name}} className="custom-class" />);
+    expect(screen.getByTestId('{{kebabCase name}}')).toHaveClass('custom-class');
+  });
+});
+```
+
+```handlebars
+{{!-- plop/templates/component/component.stories.tsx.hbs --}}
+import type { Meta, StoryObj } from '@storybook/react';
+import { {{pascalCase name}} } from './{{pascalCase name}}';
+
+const meta: Meta<typeof {{pascalCase name}}> = {
+  title: 'Components/{{pascalCase name}}',
+  component: {{pascalCase name}},
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: 'Additional CSS class',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof {{pascalCase name}}>;
+
+export const Default: Story = {
+  args: {
+    children: 'Default content',
+  },
+};
+
+export const WithCustomClass: Story = {
+  args: {
+    children: 'Custom styled content',
+    className: 'custom-class',
+  },
+};
+```
+
+```handlebars
+{{!-- plop/templates/component/styles.module.css.hbs --}}
+.container {
+  /* Base styles */
+}
+```
+
+```handlebars
+{{!-- plop/templates/component/index.ts.hbs --}}
+export { {{pascalCase name}} } from './{{pascalCase name}}';
+export type { {{pascalCase name}}Props } from './{{pascalCase name}}';
+```
+
+### API Endpoint Generator
+
+```javascript
+// plop/generators/api-endpoint.js
+module.exports = function (plop) {
+  plop.setGenerator('api-endpoint', {
+    description: 'Create an API endpoint',
+    prompts: [
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Endpoint name (e.g., users, products):',
+        validate: (value) => {
+          if (!value) return 'Endpoint name is required';
+          if (!/^[a-z][a-z0-9-]*$/.test(value)) {
+            return 'Endpoint name must be lowercase with hyphens';
+          }
+          return true;
+        },
+      },
+      {
+        type: 'list',
+        name: 'framework',
+        message: 'API framework:',
+        choices: [
+          { name: 'Express.js', value: 'express' },
+          { name: 'Fastify', value: 'fastify' },
+          { name: 'Next.js API Routes', value: 'nextjs' },
+          { name: 'NestJS', value: 'nestjs' },
+        ],
+        default: 'express',
+      },
+      {
+        type: 'checkbox',
+        name: 'methods',
+        message: 'HTTP methods to generate:',
+        choices: [
+          { name: 'GET (list)', value: 'list', checked: true },
+          { name: 'GET (single)', value: 'get', checked: true },
+          { name: 'POST (create)', value: 'create', checked: true },
+          { name: 'PUT (update)', value: 'update', checked: true },
+          { name: 'DELETE', value: 'delete', checked: true },
+        ],
+      },
+      {
+        type: 'confirm',
+        name: 'hasAuth',
+        message: 'Require authentication?',
+        default: true,
+      },
+      {
+        type: 'confirm',
+        name: 'hasValidation',
+        message: 'Include request validation?',
+        default: true,
+      },
+    ],
+    actions: (data) => {
+      const actions = [];
+
+      if (data.framework === 'express') {
+        actions.push(
+          {
+            type: 'add',
+            path: 'src/routes/{{kebabCase name}}.routes.ts',
+            templateFile: 'plop/templates/api/express/routes.ts.hbs',
+          },
+          {
+            type: 'add',
+            path: 'src/controllers/{{kebabCase name}}.controller.ts',
+            templateFile: 'plop/templates/api/express/controller.ts.hbs',
+          },
+          {
+            type: 'add',
+            path: 'src/services/{{kebabCase name}}.service.ts',
+            templateFile: 'plop/templates/api/express/service.ts.hbs',
+          }
+        );
+
+        if (data.hasValidation) {
+          actions.push({
+            type: 'add',
+            path: 'src/validators/{{kebabCase name}}.validator.ts',
+            templateFile: 'plop/templates/api/express/validator.ts.hbs',
+          });
+        }
+      }
+
+      if (data.framework === 'nextjs') {
+        actions.push({
+          type: 'add',
+          path: 'src/app/api/{{kebabCase name}}/route.ts',
+          templateFile: 'plop/templates/api/nextjs/route.ts.hbs',
+        });
+
+        if (data.methods.includes('get') || data.methods.includes('update') || data.methods.includes('delete')) {
+          actions.push({
+            type: 'add',
+            path: 'src/app/api/{{kebabCase name}}/[id]/route.ts',
+            templateFile: 'plop/templates/api/nextjs/route-id.ts.hbs',
+          });
+        }
+      }
+
+      if (data.framework === 'nestjs') {
+        actions.push(
+          {
+            type: 'add',
+            path: 'src/{{kebabCase name}}/{{kebabCase name}}.module.ts',
+            templateFile: 'plop/templates/api/nestjs/module.ts.hbs',
+          },
+          {
+            type: 'add',
+            path: 'src/{{kebabCase name}}/{{kebabCase name}}.controller.ts',
+            templateFile: 'plop/templates/api/nestjs/controller.ts.hbs',
+          },
+          {
+            type: 'add',
+            path: 'src/{{kebabCase name}}/{{kebabCase name}}.service.ts',
+            templateFile: 'plop/templates/api/nestjs/service.ts.hbs',
+          },
+          {
+            type: 'add',
+            path: 'src/{{kebabCase name}}/dto/create-{{kebabCase name}}.dto.ts',
+            templateFile: 'plop/templates/api/nestjs/create-dto.ts.hbs',
+          },
+          {
+            type: 'add',
+            path: 'src/{{kebabCase name}}/dto/update-{{kebabCase name}}.dto.ts',
+            templateFile: 'plop/templates/api/nestjs/update-dto.ts.hbs',
+          }
+        );
+      }
+
+      // Add tests
+      actions.push({
+        type: 'add',
+        path: 'src/__tests__/{{kebabCase name}}.test.ts',
+        templateFile: `plop/templates/api/${data.framework}/test.ts.hbs`,
+      });
+
+      return actions;
+    },
+  });
+};
+```
+
+### Express API Templates
+
+```handlebars
+{{!-- plop/templates/api/express/routes.ts.hbs --}}
+import { Router } from 'express';
+import * as controller from '../controllers/{{kebabCase name}}.controller';
+{{#if hasAuth}}
+import { authenticate } from '../middleware/auth';
+{{/if}}
+{{#if hasValidation}}
+import { validate } from '../middleware/validate';
+import * as validators from '../validators/{{kebabCase name}}.validator';
+{{/if}}
+
+const router = Router();
+
+{{#if hasAuth}}
+// Apply authentication to all routes
+router.use(authenticate);
+{{/if}}
+
+{{#each methods}}
+{{#ifEquals this "list"}}
+// GET /{{kebabCase ../name}} - List all {{kebabCase ../name}}
+router.get('/', controller.list);
+{{/ifEquals}}
+{{#ifEquals this "get"}}
+// GET /{{kebabCase ../name}}/:id - Get single {{kebabCase ../name}}
+router.get('/:id', controller.getById);
+{{/ifEquals}}
+{{#ifEquals this "create"}}
+// POST /{{kebabCase ../name}} - Create new {{kebabCase ../name}}
+router.post(
+  '/',
+{{#if ../hasValidation}}
+  validate(validators.create{{pascalCase ../name}}Schema),
+{{/if}}
+  controller.create
+);
+{{/ifEquals}}
+{{#ifEquals this "update"}}
+// PUT /{{kebabCase ../name}}/:id - Update {{kebabCase ../name}}
+router.put(
+  '/:id',
+{{#if ../hasValidation}}
+  validate(validators.update{{pascalCase ../name}}Schema),
+{{/if}}
+  controller.update
+);
+{{/ifEquals}}
+{{#ifEquals this "delete"}}
+// DELETE /{{kebabCase ../name}}/:id - Delete {{kebabCase ../name}}
+router.delete('/:id', controller.remove);
+{{/ifEquals}}
+{{/each}}
+
+export default router;
+```
+
+```handlebars
+{{!-- plop/templates/api/express/controller.ts.hbs --}}
+import { Request, Response, NextFunction } from 'express';
+import * as {{camelCase name}}Service from '../services/{{kebabCase name}}.service';
+import { AppError } from '../utils/errors';
+
+{{#each methods}}
+{{#ifEquals this "list"}}
+export const list = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { page = 1, limit = 10, ...filters } = req.query;
+    const result = await {{camelCase ../name}}Service.findAll({
+      page: Number(page),
+      limit: Number(limit),
+      filters,
+    });
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+{{/ifEquals}}
+{{#ifEquals this "get"}}
+
+export const getById = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const item = await {{camelCase ../name}}Service.findById(id);
+
+    if (!item) {
+      throw new AppError('{{pascalCase ../name}} not found', 404);
+    }
+
+    res.json(item);
+  } catch (error) {
+    next(error);
+  }
+};
+{{/ifEquals}}
+{{#ifEquals this "create"}}
+
+export const create = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const item = await {{camelCase ../name}}Service.create(req.body);
+    res.status(201).json(item);
+  } catch (error) {
+    next(error);
+  }
+};
+{{/ifEquals}}
+{{#ifEquals this "update"}}
+
+export const update = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const item = await {{camelCase ../name}}Service.update(id, req.body);
+
+    if (!item) {
+      throw new AppError('{{pascalCase ../name}} not found', 404);
+    }
+
+    res.json(item);
+  } catch (error) {
+    next(error);
+  }
+};
+{{/ifEquals}}
+{{#ifEquals this "delete"}}
+
+export const remove = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    await {{camelCase ../name}}Service.remove(id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};
+{{/ifEquals}}
+{{/each}}
+```
+
+```handlebars
+{{!-- plop/templates/api/express/service.ts.hbs --}}
+import { db } from '../db';
+
+export interface {{pascalCase name}} {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  // Add your fields here
+}
+
+export interface Create{{pascalCase name}}Input {
+  // Add your input fields here
+}
+
+export interface Update{{pascalCase name}}Input {
+  // Add your update fields here
+}
+
+export interface FindAllOptions {
+  page: number;
+  limit: number;
+  filters: Record<string, unknown>;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export const findAll = async (
+  options: FindAllOptions
+): Promise<PaginatedResult<{{pascalCase name}}>> => {
+  const { page, limit, filters } = options;
+  const offset = (page - 1) * limit;
+
+  // Replace with your database query
+  const [data, total] = await Promise.all([
+    db.{{camelCase name}}.findMany({
+      where: filters,
+      skip: offset,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+    }),
+    db.{{camelCase name}}.count({ where: filters }),
+  ]);
+
+  return {
+    data,
+    total,
+    page,
+    limit,
+    totalPages: Math.ceil(total / limit),
+  };
+};
+
+export const findById = async (id: string): Promise<{{pascalCase name}} | null> => {
+  return db.{{camelCase name}}.findUnique({ where: { id } });
+};
+
+export const create = async (
+  input: Create{{pascalCase name}}Input
+): Promise<{{pascalCase name}}> => {
+  return db.{{camelCase name}}.create({ data: input });
+};
+
+export const update = async (
+  id: string,
+  input: Update{{pascalCase name}}Input
+): Promise<{{pascalCase name}} | null> => {
+  return db.{{camelCase name}}.update({
+    where: { id },
+    data: input,
+  });
+};
+
+export const remove = async (id: string): Promise<void> => {
+  await db.{{camelCase name}}.delete({ where: { id } });
+};
+```
+
+```handlebars
+{{!-- plop/templates/api/express/validator.ts.hbs --}}
+import { z } from 'zod';
+
+export const create{{pascalCase name}}Schema = z.object({
+  body: z.object({
+    // Add your validation rules here
+    // name: z.string().min(1).max(255),
+    // email: z.string().email(),
+  }),
+});
+
+export const update{{pascalCase name}}Schema = z.object({
+  params: z.object({
+    id: z.string().uuid(),
+  }),
+  body: z.object({
+    // Add your validation rules here (all optional for updates)
+    // name: z.string().min(1).max(255).optional(),
+    // email: z.string().email().optional(),
+  }),
+});
+
+export type Create{{pascalCase name}}Input = z.infer<typeof create{{pascalCase name}}Schema>['body'];
+export type Update{{pascalCase name}}Input = z.infer<typeof update{{pascalCase name}}Schema>['body'];
+```
+
+### Database Migration Generator
+
+```javascript
+// plop/generators/database-migration.js
+module.exports = function (plop) {
+  plop.setGenerator('migration', {
+    description: 'Create a database migration',
+    prompts: [
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Migration name (e.g., add-users-table, add-email-index):',
+        validate: (value) => {
+          if (!value) return 'Migration name is required';
+          if (!/^[a-z][a-z0-9-]*$/.test(value)) {
+            return 'Migration name must be lowercase with hyphens';
+          }
+          return true;
+        },
+      },
+      {
+        type: 'list',
+        name: 'type',
+        message: 'Migration type:',
+        choices: [
+          { name: 'Create Table', value: 'create-table' },
+          { name: 'Alter Table', value: 'alter-table' },
+          { name: 'Add Index', value: 'add-index' },
+          { name: 'Add Foreign Key', value: 'add-fk' },
+          { name: 'Custom SQL', value: 'custom' },
+        ],
+      },
+      {
+        type: 'input',
+        name: 'tableName',
+        message: 'Table name:',
+        when: (answers) => ['create-table', 'alter-table', 'add-index', 'add-fk'].includes(answers.type),
+      },
+      {
+        type: 'list',
+        name: 'tool',
+        message: 'Migration tool:',
+        choices: [
+          { name: 'Prisma', value: 'prisma' },
+          { name: 'TypeORM', value: 'typeorm' },
+          { name: 'Knex.js', value: 'knex' },
+          { name: 'Sequelize', value: 'sequelize' },
+          { name: 'Raw SQL', value: 'sql' },
+        ],
+        default: 'prisma',
+      },
+    ],
+    actions: (data) => {
+      const timestamp = new Date().toISOString().replace(/[-:T.]/g, '').slice(0, 14);
+      const actions = [];
+
+      if (data.tool === 'prisma') {
+        actions.push({
+          type: 'add',
+          path: 'prisma/migrations/{{timestamp}}_{{kebabCase name}}/migration.sql',
+          templateFile: 'plop/templates/migration/prisma.sql.hbs',
+          data: { timestamp },
+        });
+      } else if (data.tool === 'typeorm') {
+        actions.push({
+          type: 'add',
+          path: 'src/migrations/{{timestamp}}-{{pascalCase name}}.ts',
+          templateFile: 'plop/templates/migration/typeorm.ts.hbs',
+          data: { timestamp },
+        });
+      } else if (data.tool === 'knex') {
+        actions.push({
+          type: 'add',
+          path: 'migrations/{{timestamp}}_{{snakeCase name}}.ts',
+          templateFile: 'plop/templates/migration/knex.ts.hbs',
+          data: { timestamp },
+        });
+      } else if (data.tool === 'sql') {
+        actions.push(
+          {
+            type: 'add',
+            path: 'migrations/{{timestamp}}_{{snakeCase name}}_up.sql',
+            templateFile: 'plop/templates/migration/sql-up.sql.hbs',
+            data: { timestamp },
+          },
+          {
+            type: 'add',
+            path: 'migrations/{{timestamp}}_{{snakeCase name}}_down.sql',
+            templateFile: 'plop/templates/migration/sql-down.sql.hbs',
+            data: { timestamp },
+          }
+        );
+      }
+
+      return actions;
+    },
+  });
+};
+```
+
+### Migration Templates
+
+```handlebars
+{{!-- plop/templates/migration/typeorm.ts.hbs --}}
+import { MigrationInterface, QueryRunner, Table, TableIndex, TableForeignKey } from 'typeorm';
+
+export class {{pascalCase name}}{{timestamp}} implements MigrationInterface {
+  name = '{{pascalCase name}}{{timestamp}}';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+{{#ifEquals type "create-table"}}
+    await queryRunner.createTable(
+      new Table({
+        name: '{{snakeCase tableName}}',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          // Add your columns here
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true
+    );
+{{/ifEquals}}
+{{#ifEquals type "alter-table"}}
+    await queryRunner.query(`
+      ALTER TABLE "{{snakeCase tableName}}"
+      -- Add your alterations here
+    `);
+{{/ifEquals}}
+{{#ifEquals type "add-index"}}
+    await queryRunner.createIndex(
+      '{{snakeCase tableName}}',
+      new TableIndex({
+        name: 'IDX_{{upperCase (snakeCase tableName)}}_COLUMN',
+        columnNames: ['column_name'],
+      })
+    );
+{{/ifEquals}}
+{{#ifEquals type "add-fk"}}
+    await queryRunner.createForeignKey(
+      '{{snakeCase tableName}}',
+      new TableForeignKey({
+        columnNames: ['foreign_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'referenced_table',
+        onDelete: 'CASCADE',
+      })
+    );
+{{/ifEquals}}
+{{#ifEquals type "custom"}}
+    await queryRunner.query(`
+      -- Add your custom SQL here
+    `);
+{{/ifEquals}}
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+{{#ifEquals type "create-table"}}
+    await queryRunner.dropTable('{{snakeCase tableName}}');
+{{/ifEquals}}
+{{#ifEquals type "alter-table"}}
+    await queryRunner.query(`
+      ALTER TABLE "{{snakeCase tableName}}"
+      -- Reverse your alterations here
+    `);
+{{/ifEquals}}
+{{#ifEquals type "add-index"}}
+    await queryRunner.dropIndex('{{snakeCase tableName}}', 'IDX_{{upperCase (snakeCase tableName)}}_COLUMN');
+{{/ifEquals}}
+{{#ifEquals type "add-fk"}}
+    const table = await queryRunner.getTable('{{snakeCase tableName}}');
+    const foreignKey = table.foreignKeys.find(
+      (fk) => fk.columnNames.indexOf('foreign_id') !== -1
+    );
+    await queryRunner.dropForeignKey('{{snakeCase tableName}}', foreignKey);
+{{/ifEquals}}
+{{#ifEquals type "custom"}}
+    await queryRunner.query(`
+      -- Reverse your custom SQL here
+    `);
+{{/ifEquals}}
+  }
+}
+```
+
+```handlebars
+{{!-- plop/templates/migration/knex.ts.hbs --}}
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+{{#ifEquals type "create-table"}}
+  return knex.schema.createTable('{{snakeCase tableName}}', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    // Add your columns here
+    table.timestamps(true, true);
+  });
+{{/ifEquals}}
+{{#ifEquals type "alter-table"}}
+  return knex.schema.alterTable('{{snakeCase tableName}}', (table) => {
+    // Add your alterations here
+  });
+{{/ifEquals}}
+{{#ifEquals type "add-index"}}
+  return knex.schema.alterTable('{{snakeCase tableName}}', (table) => {
+    table.index(['column_name'], 'idx_{{snakeCase tableName}}_column');
+  });
+{{/ifEquals}}
+{{#ifEquals type "add-fk"}}
+  return knex.schema.alterTable('{{snakeCase tableName}}', (table) => {
+    table.foreign('foreign_id').references('id').inTable('referenced_table').onDelete('CASCADE');
+  });
+{{/ifEquals}}
+{{#ifEquals type "custom"}}
+  return knex.raw(`
+    -- Add your custom SQL here
+  `);
+{{/ifEquals}}
+}
+
+export async function down(knex: Knex): Promise<void> {
+{{#ifEquals type "create-table"}}
+  return knex.schema.dropTable('{{snakeCase tableName}}');
+{{/ifEquals}}
+{{#ifEquals type "alter-table"}}
+  return knex.schema.alterTable('{{snakeCase tableName}}', (table) => {
+    // Reverse your alterations here
+  });
+{{/ifEquals}}
+{{#ifEquals type "add-index"}}
+  return knex.schema.alterTable('{{snakeCase tableName}}', (table) => {
+    table.dropIndex(['column_name'], 'idx_{{snakeCase tableName}}_column');
+  });
+{{/ifEquals}}
+{{#ifEquals type "add-fk"}}
+  return knex.schema.alterTable('{{snakeCase tableName}}', (table) => {
+    table.dropForeign(['foreign_id']);
+  });
+{{/ifEquals}}
+{{#ifEquals type "custom"}}
+  return knex.raw(`
+    -- Reverse your custom SQL here
+  `);
+{{/ifEquals}}
+}
+```
+
+### React Hook Generator
+
+```javascript
+// plop/generators/hook.js
+module.exports = function (plop) {
+  plop.setGenerator('hook', {
+    description: 'Create a React hook',
+    prompts: [
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Hook name (without "use" prefix):',
+        validate: (value) => {
+          if (!value) return 'Hook name is required';
+          if (!/^[A-Z][a-zA-Z0-9]*$/.test(value)) {
+            return 'Hook name must be PascalCase';
+          }
+          return true;
+        },
+      },
+      {
+        type: 'list',
+        name: 'type',
+        message: 'Hook type:',
+        choices: [
+          { name: 'State Hook', value: 'state' },
+          { name: 'Effect Hook', value: 'effect' },
+          { name: 'API/Fetch Hook', value: 'api' },
+          { name: 'Form Hook', value: 'form' },
+          { name: 'Custom Logic Hook', value: 'custom' },
+        ],
+        default: 'state',
+      },
+      {
+        type: 'confirm',
+        name: 'hasTests',
+        message: 'Include tests?',
+        default: true,
+      },
+    ],
+    actions: (data) => {
+      const actions = [
+        {
+          type: 'add',
+          path: 'src/hooks/use{{pascalCase name}}/use{{pascalCase name}}.ts',
+          templateFile: `plop/templates/hook/${data.type}.ts.hbs`,
+        },
+        {
+          type: 'add',
+          path: 'src/hooks/use{{pascalCase name}}/index.ts',
+          templateFile: 'plop/templates/hook/index.ts.hbs',
+        },
+      ];
+
+      if (data.hasTests) {
+        actions.push({
+          type: 'add',
+          path: 'src/hooks/use{{pascalCase name}}/use{{pascalCase name}}.test.ts',
+          templateFile: `plop/templates/hook/${data.type}.test.ts.hbs`,
+        });
+      }
+
+      return actions;
+    },
+  });
+};
+```
+
+```handlebars
+{{!-- plop/templates/hook/api.ts.hbs --}}
+import { useState, useEffect, useCallback } from 'react';
+
+interface Use{{pascalCase name}}Options<T> {
+  /** Initial data */
+  initialData?: T;
+  /** Enable automatic fetching */
+  enabled?: boolean;
+  /** Refetch interval in milliseconds */
+  refetchInterval?: number;
+}
+
+interface Use{{pascalCase name}}Result<T> {
+  data: T | undefined;
+  error: Error | null;
+  isLoading: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Hook for fetching and managing {{name}} data
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, error, refetch } = use{{pascalCase name}}({
+ *   enabled: true,
+ * });
+ * ```
+ */
+export function use{{pascalCase name}}<T = unknown>(
+  options: Use{{pascalCase name}}Options<T> = {}
+): Use{{pascalCase name}}Result<T> {
+  const { initialData, enabled = true, refetchInterval } = options;
+
+  const [data, setData] = useState<T | undefined>(initialData);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // Replace with your API call
+      const response = await fetch('/api/{{kebabCase name}}');
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const result = await response.json();
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (enabled) {
+      fetchData();
+    }
+  }, [enabled, fetchData]);
+
+  useEffect(() => {
+    if (refetchInterval && enabled) {
+      const interval = setInterval(fetchData, refetchInterval);
+      return () => clearInterval(interval);
+    }
+  }, [refetchInterval, enabled, fetchData]);
+
+  return {
+    data,
+    error,
+    isLoading,
+    isError: error !== null,
+    isSuccess: data !== undefined && error === null,
+    refetch: fetchData,
+  };
+}
+```
+
+```handlebars
+{{!-- plop/templates/hook/api.test.ts.hbs --}}
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { use{{pascalCase name}} } from './use{{pascalCase name}}';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+describe('use{{pascalCase name}}', () => {
+  beforeEach(() => {
+    (fetch as jest.Mock).mockClear();
+  });
+
+  it('should fetch data successfully', async () => {
+    const mockData = { id: 1, name: 'Test' };
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    const { result } = renderHook(() => use{{pascalCase name}}());
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('should handle errors', async () => {
+    (fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => use{{pascalCase name}}());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  it('should not fetch when disabled', () => {
+    renderHook(() => use{{pascalCase name}}({ enabled: false }));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should refetch on demand', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 1 }),
+    });
+
+    const { result } = renderHook(() => use{{pascalCase name}}());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+---
+
+## Copier Templates
+
+Copier is a Python-based project templating tool that supports advanced features like
+conditional files and post-generation hooks.
+
+### Project Structure
+
+```text
+my-copier-template/
+  copier.yml                 # Template configuration
+  template/                  # Template files
+    {{project_slug}}/
+      pyproject.toml.jinja
+      README.md.jinja
+      src/
+        {{project_slug}}/
+          __init__.py.jinja
+          main.py.jinja
+      tests/
+        __init__.py
+        test_main.py.jinja
+  hooks/
+    post_gen_project.py      # Post-generation hook
+```
+
+### Copier Configuration
+
+```yaml
+# copier.yml
+_min_copier_version: "9.0.0"
+_subdirectory: template
+_skip_if_exists:
+  - "*.lock"
+  - ".env"
+
+# Project metadata
+project_name:
+  type: str
+  help: "Project name"
+  placeholder: "My Awesome Project"
+  validator: >-
+    {% if not project_name %}
+    Project name is required
+    {% endif %}
+
+project_slug:
+  type: str
+  help: "Project slug (used for package name)"
+  default: "{{ project_name | lower | replace(' ', '-') | replace('_', '-') }}"
+  validator: >-
+    {% if not project_slug | regex_search('^[a-z][a-z0-9-]*$') %}
+    Project slug must be lowercase with hyphens
+    {% endif %}
+
+project_description:
+  type: str
+  help: "Short project description"
+  default: "A new project"
+
+author_name:
+  type: str
+  help: "Author name"
+  default: "{{ 'git config user.name' | shell | trim }}"
+
+author_email:
+  type: str
+  help: "Author email"
+  default: "{{ 'git config user.email' | shell | trim }}"
+
+python_version:
+  type: str
+  help: "Minimum Python version"
+  choices:
+    - "3.10"
+    - "3.11"
+    - "3.12"
+  default: "3.11"
+
+# Features
+use_pytest:
+  type: bool
+  help: "Use pytest for testing?"
+  default: true
+
+use_mypy:
+  type: bool
+  help: "Use mypy for type checking?"
+  default: true
+
+use_ruff:
+  type: bool
+  help: "Use ruff for linting?"
+  default: true
+
+use_pre_commit:
+  type: bool
+  help: "Use pre-commit hooks?"
+  default: true
+
+use_docker:
+  type: bool
+  help: "Include Docker configuration?"
+  default: false
+
+use_github_actions:
+  type: bool
+  help: "Include GitHub Actions CI?"
+  default: true
+
+# License
+license:
+  type: str
+  help: "License type"
+  choices:
+    MIT: "MIT License"
+    Apache-2.0: "Apache License 2.0"
+    GPL-3.0: "GNU General Public License v3"
+    BSD-3-Clause: "BSD 3-Clause License"
+    None: "No license"
+  default: "MIT"
+```
+
+### Copier Template Files
+
+```jinja2
+{#- template/{{project_slug}}/pyproject.toml.jinja -#}
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ project_slug }}"
+version = "0.1.0"
+description = "{{ project_description }}"
+readme = "README.md"
+requires-python = ">={{ python_version }}"
+{%- if license != "None" %}
+license = "{{ license }}"
+{%- endif %}
+authors = [
+    { name = "{{ author_name }}", email = "{{ author_email }}" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+{%- if license != "None" %}
+    "License :: OSI Approved :: {{ license }} License",
+{%- endif %}
+    "Programming Language :: Python :: {{ python_version }}",
+]
+
+[project.optional-dependencies]
+dev = [
+{%- if use_pytest %}
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+{%- endif %}
+{%- if use_mypy %}
+    "mypy>=1.0.0",
+{%- endif %}
+{%- if use_ruff %}
+    "ruff>=0.1.0",
+{%- endif %}
+{%- if use_pre_commit %}
+    "pre-commit>=3.0.0",
+{%- endif %}
+]
+
+{%- if use_ruff %}
+
+[tool.ruff]
+target-version = "py{{ python_version | replace('.', '') }}"
+line-length = 100
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # Pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+]
+
+[tool.ruff.isort]
+known-first-party = ["{{ project_slug | replace('-', '_') }}"]
+{%- endif %}
+
+{%- if use_mypy %}
+
+[tool.mypy]
+python_version = "{{ python_version }}"
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+{%- endif %}
+
+{%- if use_pytest %}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --cov={{ project_slug | replace('-', '_') }} --cov-report=term-missing"
+{%- endif %}
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]
+```
+
+````jinja2
+{#- template/{{project_slug}}/README.md.jinja -#}
+# {{ project_name }}
+
+{{ project_description }}
+
+## Installation
+
+```bash
+pip install {{ project_slug }}
+```
+
+## Development
+
+### Setup
+
+```bash
+# Clone repository
+git clone https://github.com/{{ author_name | lower | replace(' ', '') }}/{{ project_slug }}.git
+cd {{ project_slug }}
+
+# Create virtual environment
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install dependencies
+pip install -e ".[dev]"
+{%- if use_pre_commit %}
+
+# Install pre-commit hooks
+pre-commit install
+{%- endif %}
+```
+
+### Commands
+
+```bash
+{%- if use_pytest %}
+# Run tests
+pytest
+
+# Run tests with coverage
+pytest --cov
+{%- endif %}
+
+{%- if use_ruff %}
+# Lint code
+ruff check .
+
+# Format code
+ruff format .
+{%- endif %}
+
+{%- if use_mypy %}
+# Type check
+mypy src
+{%- endif %}
+```
+
+## License
+
+{%- if license != "None" %}
+This project is licensed under the {{ license }} License - see the [LICENSE](LICENSE) file for details.
+{%- else %}
+This project is proprietary.
+{%- endif %}
+````
+
+```jinja2
+{#- template/{{project_slug}}/src/{{project_slug|replace('-', '_')}}/__init__.py.jinja -#}
+"""{{ project_name }}
+
+{{ project_description }}
+"""
+
+__version__ = "0.1.0"
+__author__ = "{{ author_name }}"
+__email__ = "{{ author_email }}"
+```
+
+```jinja2
+{#- template/{{project_slug}}/src/{{project_slug|replace('-', '_')}}/main.py.jinja -#}
+"""Main module for {{ project_name }}."""
+
+from __future__ import annotations
+
+
+def main() -> int:
+    """Entry point for the application."""
+    print("Hello from {{ project_name }}!")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+```jinja2
+{#- template/{{project_slug}}/tests/test_main.py.jinja -#}
+"""Tests for main module."""
+
+from {{ project_slug | replace('-', '_') }}.main import main
+
+
+def test_main() -> None:
+    """Test main function returns 0."""
+    assert main() == 0
+```
+
+### Conditional Docker Files
+
+```jinja2
+{#- template/{{project_slug}}/Dockerfile.jinja -#}
+{%- if use_docker %}
+# Build stage
+FROM python:{{ python_version }}-slim as builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN pip install --no-cache-dir build
+
+# Copy source
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+# Build wheel
+RUN python -m build --wheel
+
+# Runtime stage
+FROM python:{{ python_version }}-slim
+
+WORKDIR /app
+
+# Copy wheel from builder
+COPY --from=builder /app/dist/*.whl ./
+
+# Install package
+RUN pip install --no-cache-dir *.whl && rm *.whl
+
+# Create non-root user
+RUN useradd --create-home appuser
+USER appuser
+
+ENTRYPOINT ["python", "-m", "{{ project_slug | replace('-', '_') }}"]
+{%- endif %}
+```
+
+### GitHub Actions Conditional
+
+```jinja2
+{#- template/{{project_slug}}/.github/workflows/ci.yml.jinja -#}
+{%- if use_github_actions %}
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["{{ python_version }}", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ '{{' }} matrix.python-version {{ '}}' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ '{{' }} matrix.python-version {{ '}}' }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+{%- if use_ruff %}
+
+      - name: Lint with ruff
+        run: ruff check .
+{%- endif %}
+{%- if use_mypy %}
+
+      - name: Type check with mypy
+        run: mypy src
+{%- endif %}
+{%- if use_pytest %}
+
+      - name: Test with pytest
+        run: pytest --cov --cov-report=xml
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+{%- endif %}
+{%- endif %}
+```
+
+### Post-Generation Hook
+
+```python
+# hooks/post_gen_project.py
+"""Post-generation hook for Copier template."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_command(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    """Run a command and return the result."""
+    return subprocess.run(cmd, check=check, capture_output=True, text=True)
+
+
+def main() -> int:
+    """Main hook function."""
+    project_dir = Path.cwd()
+
+    print("Setting up project...")
+
+    # Initialize git repository
+    if not (project_dir / ".git").exists():
+        print("Initializing git repository...")
+        run_command(["git", "init"])
+        run_command(["git", "add", "."])
+        run_command(["git", "commit", "-m", "Initial commit from template"])
+
+    # Create virtual environment
+    print("Creating virtual environment...")
+    run_command([sys.executable, "-m", "venv", "venv"])
+
+    # Install dependencies
+    print("Installing dependencies...")
+    pip_path = project_dir / "venv" / "bin" / "pip"
+    if sys.platform == "win32":
+        pip_path = project_dir / "venv" / "Scripts" / "pip.exe"
+
+    run_command([str(pip_path), "install", "-e", ".[dev]"])
+
+    # Install pre-commit hooks if enabled
+    if (project_dir / ".pre-commit-config.yaml").exists():
+        print("Installing pre-commit hooks...")
+        precommit_path = project_dir / "venv" / "bin" / "pre-commit"
+        if sys.platform == "win32":
+            precommit_path = project_dir / "venv" / "Scripts" / "pre-commit.exe"
+        run_command([str(precommit_path), "install"])
+
+    print("\nProject setup complete!")
+    print(f"\nNext steps:")
+    print(f"  cd {project_dir.name}")
+    print(f"  source venv/bin/activate  # On Windows: venv\\Scripts\\activate")
+    print(f"  pytest")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+### Using Copier
+
+```bash
+# Generate new project
+copier copy https://github.com/org/my-template ./my-new-project
+
+# Generate with answers file
+copier copy --answers-file .copier-answers.yml https://github.com/org/my-template .
+
+# Update existing project
+copier update
+
+# Update with specific version
+copier update --vcs-ref v2.0.0
+```
+
+---
+
+## Yeoman Generators
+
+Yeoman is a scaffolding tool with a rich ecosystem of generators.
+
+### Generator Structure
+
+```text
+generator-my-project/
+  package.json
+  generators/
+    app/
+      index.js
+      templates/
+        package.json.ejs
+        src/
+          index.ts.ejs
+    component/
+      index.js
+      templates/
+        component.tsx.ejs
+```
+
+### Yeoman Generator Package
+
+```json
+{
+  "name": "generator-my-project",
+  "version": "1.0.0",
+  "description": "Yeoman generator for my project",
+  "files": ["generators"],
+  "keywords": ["yeoman-generator"],
+  "dependencies": {
+    "yeoman-generator": "^6.0.0",
+    "chalk": "^5.0.0",
+    "yosay": "^2.0.2"
+  },
+  "devDependencies": {
+    "yeoman-test": "^8.0.0"
+  }
+}
+```
+
+### Main App Generator
+
+```javascript
+// generators/app/index.js
+import Generator from 'yeoman-generator';
+import chalk from 'chalk';
+import yosay from 'yosay';
+
+export default class extends Generator {
+  constructor(args, opts) {
+    super(args, opts);
+
+    // Register options
+    this.option('typescript', {
+      type: Boolean,
+      description: 'Use TypeScript',
+      default: true,
+    });
+
+    this.option('docker', {
+      type: Boolean,
+      description: 'Include Docker configuration',
+      default: false,
+    });
+  }
+
+  async prompting() {
+    this.log(yosay(`Welcome to the ${chalk.red('my-project')} generator!`));
+
+    this.answers = await this.prompt([
+      {
+        type: 'input',
+        name: 'projectName',
+        message: 'Project name:',
+        default: this.appname,
+        validate: (input) => {
+          if (!input) return 'Project name is required';
+          if (!/^[a-z][a-z0-9-]*$/.test(input)) {
+            return 'Project name must be lowercase with hyphens';
+          }
+          return true;
+        },
+      },
+      {
+        type: 'input',
+        name: 'description',
+        message: 'Project description:',
+        default: 'A new project',
+      },
+      {
+        type: 'list',
+        name: 'packageManager',
+        message: 'Package manager:',
+        choices: ['npm', 'yarn', 'pnpm'],
+        default: 'npm',
+      },
+      {
+        type: 'checkbox',
+        name: 'features',
+        message: 'Select features:',
+        choices: [
+          { name: 'ESLint', value: 'eslint', checked: true },
+          { name: 'Prettier', value: 'prettier', checked: true },
+          { name: 'Jest', value: 'jest', checked: true },
+          { name: 'Husky (git hooks)', value: 'husky', checked: true },
+          { name: 'GitHub Actions', value: 'github-actions', checked: true },
+        ],
+      },
+      {
+        type: 'list',
+        name: 'framework',
+        message: 'Frontend framework:',
+        choices: [
+          { name: 'None (Node.js only)', value: 'none' },
+          { name: 'React', value: 'react' },
+          { name: 'Vue', value: 'vue' },
+          { name: 'Next.js', value: 'nextjs' },
+        ],
+        default: 'none',
+      },
+    ]);
+  }
+
+  writing() {
+    const context = {
+      projectName: this.answers.projectName,
+      description: this.answers.description,
+      typescript: this.options.typescript,
+      docker: this.options.docker,
+      features: this.answers.features,
+      framework: this.answers.framework,
+      hasEslint: this.answers.features.includes('eslint'),
+      hasPrettier: this.answers.features.includes('prettier'),
+      hasJest: this.answers.features.includes('jest'),
+      hasHusky: this.answers.features.includes('husky'),
+      hasGithubActions: this.answers.features.includes('github-actions'),
+    };
+
+    // Copy package.json
+    this.fs.copyTpl(
+      this.templatePath('package.json.ejs'),
+      this.destinationPath('package.json'),
+      context
+    );
+
+    // Copy source files
+    this.fs.copyTpl(
+      this.templatePath('src/index.ts.ejs'),
+      this.destinationPath(`src/index.${this.options.typescript ? 'ts' : 'js'}`),
+      context
+    );
+
+    // Copy config files
+    if (context.hasEslint) {
+      this.fs.copyTpl(
+        this.templatePath('eslint.config.js.ejs'),
+        this.destinationPath('eslint.config.js'),
+        context
+      );
+    }
+
+    if (context.hasPrettier) {
+      this.fs.copy(
+        this.templatePath('.prettierrc'),
+        this.destinationPath('.prettierrc')
+      );
+    }
+
+    if (this.options.typescript) {
+      this.fs.copyTpl(
+        this.templatePath('tsconfig.json.ejs'),
+        this.destinationPath('tsconfig.json'),
+        context
+      );
+    }
+
+    if (this.options.docker) {
+      this.fs.copyTpl(
+        this.templatePath('Dockerfile.ejs'),
+        this.destinationPath('Dockerfile'),
+        context
+      );
+      this.fs.copyTpl(
+        this.templatePath('docker-compose.yml.ejs'),
+        this.destinationPath('docker-compose.yml'),
+        context
+      );
+    }
+
+    if (context.hasGithubActions) {
+      this.fs.copyTpl(
+        this.templatePath('.github/workflows/ci.yml.ejs'),
+        this.destinationPath('.github/workflows/ci.yml'),
+        context
+      );
+    }
+
+    // Copy static files
+    this.fs.copy(
+      this.templatePath('.gitignore.template'),
+      this.destinationPath('.gitignore')
+    );
+
+    this.fs.copyTpl(
+      this.templatePath('README.md.ejs'),
+      this.destinationPath('README.md'),
+      context
+    );
+  }
+
+  async install() {
+    const pkgManager = this.answers.packageManager;
+
+    this.log(`\nInstalling dependencies with ${chalk.cyan(pkgManager)}...`);
+
+    if (pkgManager === 'npm') {
+      this.spawnCommandSync('npm', ['install']);
+    } else if (pkgManager === 'yarn') {
+      this.spawnCommandSync('yarn', ['install']);
+    } else if (pkgManager === 'pnpm') {
+      this.spawnCommandSync('pnpm', ['install']);
+    }
+  }
+
+  end() {
+    this.log('\n');
+    this.log(chalk.green('Project created successfully!'));
+    this.log('\nNext steps:');
+    this.log(`  ${chalk.cyan('cd')} ${this.answers.projectName}`);
+
+    if (this.answers.packageManager === 'npm') {
+      this.log(`  ${chalk.cyan('npm run dev')}`);
+    } else if (this.answers.packageManager === 'yarn') {
+      this.log(`  ${chalk.cyan('yarn dev')}`);
+    } else {
+      this.log(`  ${chalk.cyan('pnpm dev')}`);
+    }
+
+    this.log('\n');
+  }
+}
+```
+
+### Yeoman Templates
+
+```ejs
+<%# generators/app/templates/package.json.ejs %>
+{
+  "name": "<%= projectName %>",
+  "version": "0.1.0",
+  "description": "<%= description %>",
+  "main": "dist/index.js",
+<% if (typescript) { %>
+  "types": "dist/index.d.ts",
+<% } %>
+  "scripts": {
+<% if (typescript) { %>
+    "build": "tsc",
+    "dev": "ts-node src/index.ts",
+<% } else { %>
+    "dev": "node src/index.js",
+<% } %>
+<% if (hasJest) { %>
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+<% } %>
+<% if (hasEslint) { %>
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+<% } %>
+<% if (hasPrettier) { %>
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+<% } %>
+<% if (hasHusky) { %>
+    "prepare": "husky install",
+<% } %>
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+<% if (typescript) { %>
+    "typescript": "^5.0.0",
+    "ts-node": "^10.9.0",
+    "@types/node": "^20.0.0",
+<% } %>
+<% if (hasEslint) { %>
+    "eslint": "^9.0.0",
+<% if (typescript) { %>
+    "typescript-eslint": "^7.0.0",
+<% } %>
+<% } %>
+<% if (hasPrettier) { %>
+    "prettier": "^3.0.0",
+<% } %>
+<% if (hasJest) { %>
+    "jest": "^29.0.0",
+<% if (typescript) { %>
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+<% } %>
+<% } %>
+<% if (hasHusky) { %>
+    "husky": "^9.0.0",
+    "lint-staged": "^15.0.0",
+<% } %>
+  },
+<% if (hasHusky) { %>
+  "lint-staged": {
+    "*.{js,ts,tsx}": [
+<% if (hasEslint) { %>
+      "eslint --fix",
+<% } %>
+<% if (hasPrettier) { %>
+      "prettier --write"
+<% } %>
+    ]
+  },
+<% } %>
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}
+```
+
+### Component Sub-Generator
+
+```javascript
+// generators/component/index.js
+import Generator from 'yeoman-generator';
+import path from 'path';
+
+export default class extends Generator {
+  constructor(args, opts) {
+    super(args, opts);
+
+    this.argument('name', {
+      type: String,
+      required: true,
+      description: 'Component name',
+    });
+  }
+
+  async prompting() {
+    this.answers = await this.prompt([
+      {
+        type: 'list',
+        name: 'type',
+        message: 'Component type:',
+        choices: ['functional', 'page', 'layout'],
+        default: 'functional',
+      },
+      {
+        type: 'confirm',
+        name: 'hasStyles',
+        message: 'Include CSS module?',
+        default: true,
+      },
+      {
+        type: 'confirm',
+        name: 'hasTests',
+        message: 'Include tests?',
+        default: true,
+      },
+    ]);
+  }
+
+  writing() {
+    const componentName = this.options.name;
+    const pascalName = componentName.charAt(0).toUpperCase() + componentName.slice(1);
+    const kebabName = componentName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+
+    const basePath = this.answers.type === 'page'
+      ? 'src/pages'
+      : this.answers.type === 'layout'
+        ? 'src/layouts'
+        : 'src/components';
+
+    const context = {
+      componentName: pascalName,
+      kebabName,
+      hasStyles: this.answers.hasStyles,
+    };
+
+    // Component file
+    this.fs.copyTpl(
+      this.templatePath('component.tsx.ejs'),
+      this.destinationPath(path.join(basePath, pascalName, `${pascalName}.tsx`)),
+      context
+    );
+
+    // Index file
+    this.fs.copyTpl(
+      this.templatePath('index.ts.ejs'),
+      this.destinationPath(path.join(basePath, pascalName, 'index.ts')),
+      context
+    );
+
+    // Styles
+    if (this.answers.hasStyles) {
+      this.fs.copyTpl(
+        this.templatePath('styles.module.css.ejs'),
+        this.destinationPath(path.join(basePath, pascalName, `${pascalName}.module.css`)),
+        context
+      );
+    }
+
+    // Tests
+    if (this.answers.hasTests) {
+      this.fs.copyTpl(
+        this.templatePath('component.test.tsx.ejs'),
+        this.destinationPath(path.join(basePath, pascalName, `${pascalName}.test.tsx`)),
+        context
+      );
+    }
+  }
+
+  end() {
+    this.log(`\nComponent ${this.options.name} created successfully!`);
+  }
+}
+```
+
+### Using Yeoman
+
+```bash
+# Install generator globally
+npm install -g generator-my-project
+
+# Generate new project
+yo my-project
+
+# Generate component
+yo my-project:component Button
+
+# Generate with options
+yo my-project --typescript --docker
+```
+
+---
+
+## Package.json Scripts
+
+### Plop Integration
+
+```json
+{
+  "scripts": {
+    "generate": "plop",
+    "g:component": "plop component",
+    "g:api": "plop api-endpoint",
+    "g:migration": "plop migration",
+    "g:hook": "plop hook"
+  },
+  "devDependencies": {
+    "plop": "^4.0.0"
+  }
+}
+```
+
+### Copier Integration
+
+```json
+{
+  "scripts": {
+    "scaffold": "copier copy https://github.com/org/template .",
+    "update-template": "copier update"
+  }
+}
+```
+
+---
+
+## Best Practices
+
+### Template Organization
+
+```text
+templates/
+  # Plop templates
+  plop/
+    generators/
+      component.js
+      api-endpoint.js
+      hook.js
+    templates/
+      component/
+        component.tsx.hbs
+        index.ts.hbs
+        styles.module.css.hbs
+      api/
+        controller.ts.hbs
+        service.ts.hbs
+
+  # Copier template
+  copier-python-package/
+    copier.yml
+    template/
+    hooks/
+
+  # Yeoman generator
+  generator-my-project/
+    generators/
+      app/
+      component/
+```
+
+### Naming Conventions
+
+```javascript
+// Good - Consistent naming helpers
+plop.setHelper('pascalCase', (text) => text.replace(/(^\w|-\w)/g, clearAndUpper));
+plop.setHelper('camelCase', (text) => text.replace(/-./g, (m) => m[1].toUpperCase()));
+plop.setHelper('kebabCase', (text) => text.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase());
+plop.setHelper('snakeCase', (text) => text.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase());
+```
+
+### Validation
+
+```javascript
+// Good - Comprehensive validation
+{
+  type: 'input',
+  name: 'name',
+  validate: (value) => {
+    if (!value) return 'Name is required';
+    if (value.length < 2) return 'Name must be at least 2 characters';
+    if (!/^[A-Z][a-zA-Z0-9]*$/.test(value)) {
+      return 'Name must be PascalCase (e.g., MyComponent)';
+    }
+    return true;
+  },
+}
+```
+
+---
+
+## References
+
+- [Plop Documentation](https://plopjs.com/)
+- [Copier Documentation](https://copier.readthedocs.io/)
+- [Yeoman Documentation](https://yeoman.io/)
+- [Handlebars Documentation](https://handlebarsjs.com/)
+- [Jinja2 Documentation](https://jinja.palletsprojects.com/)
+
+---
+
+**Status**: Active

--- a/docs/04_templates/reusable_workflows_template.md
+++ b/docs/04_templates/reusable_workflows_template.md
@@ -1,0 +1,2160 @@
+---
+title: "Reusable GitHub Actions Workflows"
+description: "Library of production-ready reusable GitHub Actions workflows for CI/CD automation"
+author: "Tyler Dukes"
+tags: [github-actions, reusable-workflows, ci-cd, automation, devops]
+category: "Templates"
+status: "active"
+---
+<!-- markdownlint-disable MD013 MD024 -->
+
+## Overview
+
+This document provides a comprehensive library of reusable GitHub Actions workflows designed for
+enterprise-grade CI/CD pipelines. These workflows follow the DRY principle and can be called from
+any repository workflow.
+
+---
+
+## Build and Test Workflow
+
+### Reusable Build Workflow
+
+```yaml
+# .github/workflows/reusable-build.yml
+name: Reusable Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'Node.js version to use'
+        required: false
+        type: string
+        default: '20'
+      python-version:
+        description: 'Python version to use'
+        required: false
+        type: string
+        default: '3.11'
+      language:
+        description: 'Primary language (node, python, go, rust)'
+        required: true
+        type: string
+      working-directory:
+        description: 'Working directory for commands'
+        required: false
+        type: string
+        default: '.'
+      build-command:
+        description: 'Build command to run'
+        required: false
+        type: string
+        default: ''
+      artifact-name:
+        description: 'Name for build artifacts'
+        required: false
+        type: string
+        default: 'build-output'
+      artifact-path:
+        description: 'Path to artifacts to upload'
+        required: false
+        type: string
+        default: 'dist/'
+      cache-dependency-path:
+        description: 'Path to dependency lock file for caching'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      build-version:
+        description: 'Version of the build'
+        value: ${{ jobs.build.outputs.version }}
+      artifact-name:
+        description: 'Name of uploaded artifact'
+        value: ${{ jobs.build.outputs.artifact }}
+    secrets:
+      NPM_TOKEN:
+        required: false
+      PYPI_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      artifact: ${{ inputs.artifact-name }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        if: inputs.language == 'node'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+          cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/package-lock.json', inputs.working-directory) }}
+
+      - name: Setup Python
+        if: inputs.language == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: 'pip'
+          cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/requirements*.txt', inputs.working-directory) }}
+
+      - name: Setup Go
+        if: inputs.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: '${{ inputs.working-directory }}/go.mod'
+          cache-dependency-path: '${{ inputs.working-directory }}/go.sum'
+
+      - name: Setup Rust
+        if: inputs.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        if: inputs.language == 'rust'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install Node.js dependencies
+        if: inputs.language == 'node'
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install Python dependencies
+        if: inputs.language == 'python'
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install build wheel
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e ".[dev]"; fi
+
+      - name: Install Go dependencies
+        if: inputs.language == 'go'
+        working-directory: ${{ inputs.working-directory }}
+        run: go mod download
+
+      - name: Get version
+        id: version
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ "${{ inputs.language }}" == "node" ]; then
+            VERSION=$(node -p "require('./package.json').version")
+          elif [ "${{ inputs.language }}" == "python" ]; then
+            VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])" 2>/dev/null || echo "0.0.0")
+          elif [ "${{ inputs.language }}" == "go" ]; then
+            VERSION=$(git describe --tags --always 2>/dev/null || echo "0.0.0")
+          elif [ "${{ inputs.language }}" == "rust" ]; then
+            VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
+          else
+            VERSION="0.0.0"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build (Node.js)
+        if: inputs.language == 'node' && inputs.build-command == ''
+        working-directory: ${{ inputs.working-directory }}
+        run: npm run build
+
+      - name: Build (Python)
+        if: inputs.language == 'python' && inputs.build-command == ''
+        working-directory: ${{ inputs.working-directory }}
+        run: python -m build
+
+      - name: Build (Go)
+        if: inputs.language == 'go' && inputs.build-command == ''
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${{ steps.version.outputs.version }}" -o dist/ ./...
+
+      - name: Build (Rust)
+        if: inputs.language == 'rust' && inputs.build-command == ''
+        working-directory: ${{ inputs.working-directory }}
+        run: cargo build --release
+
+      - name: Build (Custom)
+        if: inputs.build-command != ''
+        working-directory: ${{ inputs.working-directory }}
+        run: ${{ inputs.build-command }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.working-directory }}/${{ inputs.artifact-path }}
+          retention-days: 7
+          if-no-files-found: error
+```
+
+### Reusable Test Workflow
+
+```yaml
+# .github/workflows/reusable-test.yml
+name: Reusable Test Workflow
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        description: 'Primary language (node, python, go, rust)'
+        required: true
+        type: string
+      node-version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '20'
+      python-version:
+        description: 'Python version'
+        required: false
+        type: string
+        default: '3.11'
+      working-directory:
+        description: 'Working directory'
+        required: false
+        type: string
+        default: '.'
+      test-command:
+        description: 'Custom test command'
+        required: false
+        type: string
+        default: ''
+      coverage-threshold:
+        description: 'Minimum coverage percentage'
+        required: false
+        type: number
+        default: 80
+      upload-coverage:
+        description: 'Upload coverage to Codecov'
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      coverage:
+        description: 'Test coverage percentage'
+        value: ${{ jobs.test.outputs.coverage }}
+      test-result:
+        description: 'Test result (success/failure)'
+        value: ${{ jobs.test.outputs.result }}
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    outputs:
+      coverage: ${{ steps.coverage.outputs.percentage }}
+      result: ${{ steps.result.outputs.status }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: inputs.language == 'node'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+
+      - name: Setup Python
+        if: inputs.language == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: 'pip'
+
+      - name: Setup Go
+        if: inputs.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: '${{ inputs.working-directory }}/go.mod'
+
+      - name: Setup Rust
+        if: inputs.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install dependencies (Node.js)
+        if: inputs.language == 'node'
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Install dependencies (Python)
+        if: inputs.language == 'python'
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e ".[dev]"; fi
+
+      - name: Install coverage tools (Rust)
+        if: inputs.language == 'rust'
+        run: cargo install cargo-llvm-cov
+
+      - name: Run tests (Node.js)
+        if: inputs.language == 'node' && inputs.test-command == ''
+        working-directory: ${{ inputs.working-directory }}
+        run: npm test -- --coverage --coverageReporters=json-summary --coverageReporters=lcov
+
+      - name: Run tests (Python)
+        if: inputs.language == 'python' && inputs.test-command == ''
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          pytest --cov --cov-report=xml --cov-report=json --cov-report=term
+
+      - name: Run tests (Go)
+        if: inputs.language == 'go' && inputs.test-command == ''
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+          go tool cover -func=coverage.out
+
+      - name: Run tests (Rust)
+        if: inputs.language == 'rust' && inputs.test-command == ''
+        working-directory: ${{ inputs.working-directory }}
+        run: cargo llvm-cov --lcov --output-path lcov.info
+
+      - name: Run tests (Custom)
+        if: inputs.test-command != ''
+        working-directory: ${{ inputs.working-directory }}
+        run: ${{ inputs.test-command }}
+
+      - name: Extract coverage
+        id: coverage
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ "${{ inputs.language }}" == "node" ]; then
+            COVERAGE=$(jq '.total.lines.pct' coverage/coverage-summary.json 2>/dev/null || echo "0")
+          elif [ "${{ inputs.language }}" == "python" ]; then
+            COVERAGE=$(jq '.totals.percent_covered' coverage.json 2>/dev/null || echo "0")
+          elif [ "${{ inputs.language }}" == "go" ]; then
+            COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
+          elif [ "${{ inputs.language }}" == "rust" ]; then
+            COVERAGE=$(cargo llvm-cov report --json | jq '.data[0].totals.lines.percent' 2>/dev/null || echo "0")
+          else
+            COVERAGE="0"
+          fi
+          echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
+
+      - name: Check coverage threshold
+        id: result
+        run: |
+          COVERAGE=${{ steps.coverage.outputs.percentage }}
+          THRESHOLD=${{ inputs.coverage-threshold }}
+          if (( $(echo "$COVERAGE >= $THRESHOLD" | bc -l) )); then
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "Coverage $COVERAGE% meets threshold $THRESHOLD%"
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "::error::Coverage $COVERAGE% is below threshold $THRESHOLD%"
+            exit 1
+          fi
+
+      - name: Upload coverage to Codecov
+        if: inputs.upload-coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true
+```
+
+### Calling Build and Test Workflows
+
+```yaml
+# .github/workflows/ci.yml
+name: CI Pipeline
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      language: node
+      node-version: '20'
+      artifact-name: app-build
+      artifact-path: dist/
+    secrets: inherit
+
+  test:
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      language: node
+      node-version: '20'
+      coverage-threshold: 80
+    secrets: inherit
+
+  deploy:
+    needs: [build, test]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: app-build
+          path: dist/
+
+      - name: Deploy
+        run: ./deploy.sh
+```
+
+---
+
+## Docker Build and Push Workflow
+
+### Reusable Docker Workflow
+
+```yaml
+# .github/workflows/reusable-docker.yml
+name: Reusable Docker Build and Push
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: 'Docker image name'
+        required: true
+        type: string
+      dockerfile:
+        description: 'Path to Dockerfile'
+        required: false
+        type: string
+        default: 'Dockerfile'
+      context:
+        description: 'Docker build context'
+        required: false
+        type: string
+        default: '.'
+      platforms:
+        description: 'Target platforms (comma-separated)'
+        required: false
+        type: string
+        default: 'linux/amd64,linux/arm64'
+      push:
+        description: 'Push image to registry'
+        required: false
+        type: boolean
+        default: true
+      registry:
+        description: 'Container registry'
+        required: false
+        type: string
+        default: 'ghcr.io'
+      build-args:
+        description: 'Build arguments (multiline KEY=VALUE)'
+        required: false
+        type: string
+        default: ''
+      cache-from:
+        description: 'Cache source'
+        required: false
+        type: string
+        default: 'type=gha'
+      cache-to:
+        description: 'Cache destination'
+        required: false
+        type: string
+        default: 'type=gha,mode=max'
+      scan-image:
+        description: 'Run security scan on image'
+        required: false
+        type: boolean
+        default: true
+      sbom:
+        description: 'Generate SBOM'
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      image-digest:
+        description: 'Image digest'
+        value: ${{ jobs.build.outputs.digest }}
+      image-tags:
+        description: 'Image tags'
+        value: ${{ jobs.build.outputs.tags }}
+    secrets:
+      REGISTRY_USERNAME:
+        required: false
+      REGISTRY_PASSWORD:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    outputs:
+      digest: ${{ steps.build-push.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: inputs.push && inputs.registry == 'ghcr.io'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: inputs.push && inputs.registry == 'docker.io'
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Log in to AWS ECR
+        if: inputs.push && contains(inputs.registry, 'amazonaws.com')
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image-name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Build and push
+        id: build-push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: ${{ inputs.cache-from }}
+          cache-to: ${{ inputs.cache-to }}
+          sbom: ${{ inputs.sbom }}
+          provenance: mode=max
+
+      - name: Run Trivy vulnerability scanner
+        if: inputs.scan-image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ inputs.registry }}/${{ inputs.image-name }}:${{ github.sha }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results
+        if: inputs.scan-image
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Generate build summary
+        run: |
+          echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ inputs.registry }}/${{ inputs.image-name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Digest:** \`${{ steps.build-push.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Platforms:** ${{ inputs.platforms }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Tags" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" | tr ',' '\n' | sed 's/^/- /' >> $GITHUB_STEP_SUMMARY
+```
+
+### Multi-Stage Docker Workflow with Scanning
+
+```yaml
+# .github/workflows/reusable-docker-complete.yml
+name: Complete Docker CI/CD
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        required: true
+        type: string
+      environments:
+        description: 'Deployment environments (JSON array)'
+        required: false
+        type: string
+        default: '["staging"]'
+    secrets:
+      REGISTRY_TOKEN:
+        required: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: warning
+
+  build:
+    needs: lint
+    uses: ./.github/workflows/reusable-docker.yml
+    with:
+      image-name: ${{ inputs.image-name }}
+      push: ${{ github.event_name != 'pull_request' }}
+      scan-image: true
+    secrets: inherit
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: ${{ fromJson(inputs.environments) }}
+
+    environment:
+      name: ${{ matrix.environment }}
+      url: https://${{ matrix.environment }}.example.com
+
+    steps:
+      - name: Deploy to ${{ matrix.environment }}
+        run: |
+          echo "Deploying ${{ needs.build.outputs.image-digest }} to ${{ matrix.environment }}"
+```
+
+---
+
+## Terraform Workflow
+
+### Reusable Terraform Workflow
+
+```yaml
+# .github/workflows/reusable-terraform.yml
+name: Reusable Terraform Workflow
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Terraform working directory'
+        required: false
+        type: string
+        default: '.'
+      terraform-version:
+        description: 'Terraform version'
+        required: false
+        type: string
+        default: '1.7.0'
+      environment:
+        description: 'Deployment environment'
+        required: true
+        type: string
+      backend-config:
+        description: 'Backend configuration file'
+        required: false
+        type: string
+        default: ''
+      var-file:
+        description: 'Variable file to use'
+        required: false
+        type: string
+        default: ''
+      apply:
+        description: 'Apply changes (true/false)'
+        required: false
+        type: boolean
+        default: false
+      destroy:
+        description: 'Destroy infrastructure'
+        required: false
+        type: boolean
+        default: false
+      plan-artifact-name:
+        description: 'Name for plan artifact'
+        required: false
+        type: string
+        default: 'tfplan'
+    outputs:
+      plan-exit-code:
+        description: 'Terraform plan exit code'
+        value: ${{ jobs.terraform.outputs.plan-exit-code }}
+      has-changes:
+        description: 'Whether plan has changes'
+        value: ${{ jobs.terraform.outputs.has-changes }}
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      AZURE_CREDENTIALS:
+        required: false
+      GOOGLE_CREDENTIALS:
+        required: false
+      TF_API_TOKEN:
+        required: false
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    outputs:
+      plan-exit-code: ${{ steps.plan.outputs.exitcode }}
+      has-changes: ${{ steps.plan.outputs.has-changes }}
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+
+    environment:
+      name: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ inputs.terraform-version }}
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Configure AWS credentials
+        if: secrets.AWS_ACCESS_KEY_ID != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Configure Azure credentials
+        if: secrets.AZURE_CREDENTIALS != ''
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Configure GCP credentials
+        if: secrets.GOOGLE_CREDENTIALS != ''
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: |
+          if [ -n "${{ inputs.backend-config }}" ]; then
+            terraform init -backend-config="${{ inputs.backend-config }}"
+          else
+            terraform init
+          fi
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+
+      - name: Run TFLint
+        run: |
+          tflint --init
+          tflint --recursive --format=compact
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          set +e
+          VAR_FILE_ARG=""
+          if [ -n "${{ inputs.var-file }}" ]; then
+            VAR_FILE_ARG="-var-file=${{ inputs.var-file }}"
+          fi
+
+          if [ "${{ inputs.destroy }}" == "true" ]; then
+            terraform plan -destroy -detailed-exitcode -no-color -out=tfplan $VAR_FILE_ARG
+          else
+            terraform plan -detailed-exitcode -no-color -out=tfplan $VAR_FILE_ARG
+          fi
+
+          EXIT_CODE=$?
+          echo "exitcode=$EXIT_CODE" >> $GITHUB_OUTPUT
+
+          if [ $EXIT_CODE -eq 2 ]; then
+            echo "has-changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-changes=false" >> $GITHUB_OUTPUT
+          fi
+
+          exit 0
+
+      - name: Upload plan artifact
+        if: steps.plan.outputs.has-changes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.plan-artifact-name }}-${{ inputs.environment }}
+          path: ${{ inputs.working-directory }}/tfplan
+          retention-days: 7
+
+      - name: Terraform Plan Summary
+        run: |
+          echo "## Terraform Plan Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Working Directory:** ${{ inputs.working-directory }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Has Changes:** ${{ steps.plan.outputs.has-changes }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Terraform Apply
+        if: inputs.apply && steps.plan.outputs.has-changes == 'true'
+        run: terraform apply -auto-approve tfplan
+
+      - name: Terraform Output
+        if: inputs.apply && steps.plan.outputs.has-changes == 'true'
+        run: terraform output -json > outputs.json
+
+      - name: Upload outputs
+        if: inputs.apply && steps.plan.outputs.has-changes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-outputs-${{ inputs.environment }}
+          path: ${{ inputs.working-directory }}/outputs.json
+          retention-days: 30
+```
+
+### Terraform Multi-Environment Workflow
+
+```yaml
+# .github/workflows/terraform-multi-env.yml
+name: Terraform Multi-Environment
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options:
+          - plan
+          - apply
+          - destroy
+
+jobs:
+  plan-dev:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.environment == 'dev')
+    uses: ./.github/workflows/reusable-terraform.yml
+    with:
+      working-directory: terraform/environments/dev
+      environment: development
+      var-file: dev.tfvars
+      apply: false
+    secrets: inherit
+
+  plan-staging:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.environment == 'staging')
+    uses: ./.github/workflows/reusable-terraform.yml
+    with:
+      working-directory: terraform/environments/staging
+      environment: staging
+      var-file: staging.tfvars
+      apply: false
+    secrets: inherit
+
+  apply-dev:
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.action == 'apply' && inputs.environment == 'dev')
+    uses: ./.github/workflows/reusable-terraform.yml
+    with:
+      working-directory: terraform/environments/dev
+      environment: development
+      var-file: dev.tfvars
+      apply: true
+    secrets: inherit
+
+  apply-staging:
+    needs: apply-dev
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.action == 'apply' && inputs.environment == 'staging')
+    uses: ./.github/workflows/reusable-terraform.yml
+    with:
+      working-directory: terraform/environments/staging
+      environment: staging
+      var-file: staging.tfvars
+      apply: true
+    secrets: inherit
+
+  apply-production:
+    needs: apply-staging
+    if: github.event_name == 'workflow_dispatch' && inputs.action == 'apply' && inputs.environment == 'production'
+    uses: ./.github/workflows/reusable-terraform.yml
+    with:
+      working-directory: terraform/environments/production
+      environment: production
+      var-file: production.tfvars
+      apply: true
+    secrets: inherit
+```
+
+---
+
+## Security Scanning Workflow
+
+### Comprehensive Security Scanning
+
+```yaml
+# .github/workflows/reusable-security.yml
+name: Reusable Security Scanning
+
+on:
+  workflow_call:
+    inputs:
+      languages:
+        description: 'Languages to scan (JSON array)'
+        required: false
+        type: string
+        default: '["python", "javascript"]'
+      scan-dependencies:
+        description: 'Scan dependencies for vulnerabilities'
+        required: false
+        type: boolean
+        default: true
+      scan-secrets:
+        description: 'Scan for secrets'
+        required: false
+        type: boolean
+        default: true
+      scan-sast:
+        description: 'Run SAST scanning'
+        required: false
+        type: boolean
+        default: true
+      scan-containers:
+        description: 'Scan container images'
+        required: false
+        type: boolean
+        default: false
+      container-image:
+        description: 'Container image to scan'
+        required: false
+        type: string
+        default: ''
+      fail-on-severity:
+        description: 'Fail on vulnerability severity (CRITICAL, HIGH, MEDIUM, LOW)'
+        required: false
+        type: string
+        default: 'CRITICAL,HIGH'
+    outputs:
+      vulnerabilities-found:
+        description: 'Whether vulnerabilities were found'
+        value: ${{ jobs.summary.outputs.vulnerabilities }}
+      secrets-found:
+        description: 'Whether secrets were found'
+        value: ${{ jobs.summary.outputs.secrets }}
+
+jobs:
+  codeql:
+    if: inputs.scan-sast
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJson(inputs.languages) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  dependency-review:
+    if: github.event_name == 'pull_request' && inputs.scan-dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: ${{ inputs.fail-on-severity }}
+          deny-licenses: GPL-3.0, AGPL-3.0
+
+  secret-scanning:
+    if: inputs.scan-secrets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog Secret Scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --only-verified
+
+      - name: Gitleaks Scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  semgrep:
+    if: inputs.scan-sast
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        uses: returntocorp/semgrep-action@v1
+        with:
+          config: >-
+            p/default
+            p/owasp-top-ten
+            p/security-audit
+          generateSarif: true
+
+      - name: Upload Semgrep results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+
+  container-scan:
+    if: inputs.scan-containers && inputs.container-image != ''
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ inputs.container-image }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: ${{ inputs.fail-on-severity }}
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Run Grype scanner
+        uses: anchore/scan-action@v4
+        with:
+          image: ${{ inputs.container-image }}
+          fail-build: true
+          severity-cutoff: high
+
+  sbom:
+    if: inputs.scan-dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json
+          retention-days: 30
+
+  summary:
+    needs: [codeql, dependency-review, secret-scanning, semgrep, container-scan, sbom]
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      vulnerabilities: ${{ steps.check.outputs.vulnerabilities }}
+      secrets: ${{ steps.check.outputs.secrets }}
+
+    steps:
+      - name: Check results
+        id: check
+        run: |
+          echo "vulnerabilities=${{ contains(needs.*.result, 'failure') }}" >> $GITHUB_OUTPUT
+          echo "secrets=${{ needs.secret-scanning.result == 'failure' }}" >> $GITHUB_OUTPUT
+
+      - name: Generate security summary
+        run: |
+          echo "## Security Scan Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Scan | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| CodeQL | ${{ needs.codeql.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dependency Review | ${{ needs.dependency-review.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Secret Scanning | ${{ needs.secret-scanning.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Semgrep | ${{ needs.semgrep.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Container Scan | ${{ needs.container-scan.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| SBOM Generation | ${{ needs.sbom.result }} |" >> $GITHUB_STEP_SUMMARY
+```
+
+---
+
+## Cloud Deployment Workflows
+
+### AWS Deployment Workflow
+
+```yaml
+# .github/workflows/reusable-deploy-aws.yml
+name: Reusable AWS Deployment
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        type: string
+      aws-region:
+        description: 'AWS region'
+        required: false
+        type: string
+        default: 'us-east-1'
+      deployment-type:
+        description: 'Deployment type (ecs, lambda, s3, eks)'
+        required: true
+        type: string
+      service-name:
+        description: 'Service/function name'
+        required: true
+        type: string
+      cluster-name:
+        description: 'ECS/EKS cluster name'
+        required: false
+        type: string
+        default: ''
+      image-uri:
+        description: 'Container image URI'
+        required: false
+        type: string
+        default: ''
+      s3-bucket:
+        description: 'S3 bucket for deployment'
+        required: false
+        type: string
+        default: ''
+      artifact-path:
+        description: 'Path to deployment artifacts'
+        required: false
+        type: string
+        default: 'dist/'
+      health-check-url:
+        description: 'URL for health check'
+        required: false
+        type: string
+        default: ''
+      rollback-on-failure:
+        description: 'Rollback on deployment failure'
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      deployment-id:
+        description: 'Deployment identifier'
+        value: ${{ jobs.deploy.outputs.deployment-id }}
+      deployment-url:
+        description: 'Deployment URL'
+        value: ${{ jobs.deploy.outputs.url }}
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_ROLE_ARN:
+        required: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      deployment-id: ${{ steps.deploy.outputs.id }}
+      url: ${{ steps.deploy.outputs.url }}
+
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+
+      - name: Download build artifacts
+        if: inputs.deployment-type == 's3' || inputs.deployment-type == 'lambda'
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: ${{ inputs.artifact-path }}
+
+      - name: Deploy to ECS
+        id: deploy-ecs
+        if: inputs.deployment-type == 'ecs'
+        run: |
+          aws ecs update-service \
+            --cluster ${{ inputs.cluster-name }} \
+            --service ${{ inputs.service-name }} \
+            --force-new-deployment
+
+          aws ecs wait services-stable \
+            --cluster ${{ inputs.cluster-name }} \
+            --services ${{ inputs.service-name }}
+
+          SERVICE_URL=$(aws ecs describe-services \
+            --cluster ${{ inputs.cluster-name }} \
+            --services ${{ inputs.service-name }} \
+            --query 'services[0].loadBalancers[0].targetGroupArn' \
+            --output text)
+
+          echo "id=${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "url=https://${{ inputs.service-name }}.${{ inputs.environment }}.example.com" >> $GITHUB_OUTPUT
+
+      - name: Deploy to Lambda
+        id: deploy-lambda
+        if: inputs.deployment-type == 'lambda'
+        run: |
+          cd ${{ inputs.artifact-path }}
+          zip -r function.zip .
+
+          aws lambda update-function-code \
+            --function-name ${{ inputs.service-name }} \
+            --zip-file fileb://function.zip
+
+          aws lambda wait function-updated \
+            --function-name ${{ inputs.service-name }}
+
+          FUNCTION_URL=$(aws lambda get-function-url-config \
+            --function-name ${{ inputs.service-name }} \
+            --query 'FunctionUrl' \
+            --output text 2>/dev/null || echo "")
+
+          echo "id=${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "url=$FUNCTION_URL" >> $GITHUB_OUTPUT
+
+      - name: Deploy to S3
+        id: deploy-s3
+        if: inputs.deployment-type == 's3'
+        run: |
+          aws s3 sync ${{ inputs.artifact-path }} s3://${{ inputs.s3-bucket }}/ \
+            --delete \
+            --cache-control "max-age=31536000"
+
+          aws s3 cp ${{ inputs.artifact-path }}/index.html s3://${{ inputs.s3-bucket }}/index.html \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+          if [ -n "${{ inputs.health-check-url }}" ]; then
+            aws cloudfront create-invalidation \
+              --distribution-id $(aws cloudfront list-distributions --query "DistributionList.Items[?Origins.Items[0].DomainName=='${{ inputs.s3-bucket }}.s3.amazonaws.com'].Id" --output text) \
+              --paths "/*"
+          fi
+
+          echo "id=${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "url=https://${{ inputs.s3-bucket }}.s3-website-${{ inputs.aws-region }}.amazonaws.com" >> $GITHUB_OUTPUT
+
+      - name: Deploy to EKS
+        id: deploy-eks
+        if: inputs.deployment-type == 'eks'
+        run: |
+          aws eks update-kubeconfig --name ${{ inputs.cluster-name }} --region ${{ inputs.aws-region }}
+
+          kubectl set image deployment/${{ inputs.service-name }} \
+            ${{ inputs.service-name }}=${{ inputs.image-uri }} \
+            --record
+
+          kubectl rollout status deployment/${{ inputs.service-name }} --timeout=5m
+
+          SERVICE_URL=$(kubectl get svc ${{ inputs.service-name }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+
+          echo "id=${{ github.run_id }}" >> $GITHUB_OUTPUT
+          echo "url=https://$SERVICE_URL" >> $GITHUB_OUTPUT
+
+      - name: Set deployment output
+        id: deploy
+        run: |
+          if [ "${{ inputs.deployment-type }}" == "ecs" ]; then
+            echo "id=${{ steps.deploy-ecs.outputs.id }}" >> $GITHUB_OUTPUT
+            echo "url=${{ steps.deploy-ecs.outputs.url }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.deployment-type }}" == "lambda" ]; then
+            echo "id=${{ steps.deploy-lambda.outputs.id }}" >> $GITHUB_OUTPUT
+            echo "url=${{ steps.deploy-lambda.outputs.url }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.deployment-type }}" == "s3" ]; then
+            echo "id=${{ steps.deploy-s3.outputs.id }}" >> $GITHUB_OUTPUT
+            echo "url=${{ steps.deploy-s3.outputs.url }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.deployment-type }}" == "eks" ]; then
+            echo "id=${{ steps.deploy-eks.outputs.id }}" >> $GITHUB_OUTPUT
+            echo "url=${{ steps.deploy-eks.outputs.url }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Health check
+        if: inputs.health-check-url != ''
+        run: |
+          for i in {1..30}; do
+            if curl -sf "${{ inputs.health-check-url }}" > /dev/null; then
+              echo "Health check passed"
+              exit 0
+            fi
+            echo "Attempt $i: Health check failed, retrying..."
+            sleep 10
+          done
+          echo "Health check failed after 30 attempts"
+          exit 1
+
+      - name: Rollback on failure
+        if: failure() && inputs.rollback-on-failure && inputs.deployment-type == 'eks'
+        run: |
+          kubectl rollout undo deployment/${{ inputs.service-name }}
+          kubectl rollout status deployment/${{ inputs.service-name }} --timeout=5m
+```
+
+### Azure Deployment Workflow
+
+```yaml
+# .github/workflows/reusable-deploy-azure.yml
+name: Reusable Azure Deployment
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        type: string
+      resource-group:
+        description: 'Azure resource group'
+        required: true
+        type: string
+      deployment-type:
+        description: 'Deployment type (webapp, function, aks, storage)'
+        required: true
+        type: string
+      app-name:
+        description: 'App/Function name'
+        required: true
+        type: string
+      cluster-name:
+        description: 'AKS cluster name'
+        required: false
+        type: string
+        default: ''
+      image-uri:
+        description: 'Container image URI'
+        required: false
+        type: string
+        default: ''
+      artifact-path:
+        description: 'Path to deployment artifacts'
+        required: false
+        type: string
+        default: 'dist/'
+      storage-account:
+        description: 'Storage account name'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      deployment-url:
+        description: 'Deployment URL'
+        value: ${{ jobs.deploy.outputs.url }}
+    secrets:
+      AZURE_CREDENTIALS:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Download build artifacts
+        if: inputs.deployment-type == 'webapp' || inputs.deployment-type == 'function' || inputs.deployment-type == 'storage'
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: ${{ inputs.artifact-path }}
+
+      - name: Deploy to Web App
+        id: deploy-webapp
+        if: inputs.deployment-type == 'webapp'
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ inputs.app-name }}
+          package: ${{ inputs.artifact-path }}
+
+      - name: Deploy to Azure Functions
+        id: deploy-function
+        if: inputs.deployment-type == 'function'
+        uses: azure/functions-action@v1
+        with:
+          app-name: ${{ inputs.app-name }}
+          package: ${{ inputs.artifact-path }}
+
+      - name: Deploy to AKS
+        id: deploy-aks
+        if: inputs.deployment-type == 'aks'
+        run: |
+          az aks get-credentials --resource-group ${{ inputs.resource-group }} --name ${{ inputs.cluster-name }}
+
+          kubectl set image deployment/${{ inputs.app-name }} \
+            ${{ inputs.app-name }}=${{ inputs.image-uri }}
+
+          kubectl rollout status deployment/${{ inputs.app-name }} --timeout=5m
+
+      - name: Deploy to Azure Storage (Static Website)
+        id: deploy-storage
+        if: inputs.deployment-type == 'storage'
+        run: |
+          az storage blob upload-batch \
+            --account-name ${{ inputs.storage-account }} \
+            --destination '$web' \
+            --source ${{ inputs.artifact-path }} \
+            --overwrite
+
+      - name: Set deployment output
+        id: deploy
+        run: |
+          if [ "${{ inputs.deployment-type }}" == "webapp" ]; then
+            URL="https://${{ inputs.app-name }}.azurewebsites.net"
+          elif [ "${{ inputs.deployment-type }}" == "function" ]; then
+            URL="https://${{ inputs.app-name }}.azurewebsites.net"
+          elif [ "${{ inputs.deployment-type }}" == "aks" ]; then
+            URL=$(kubectl get svc ${{ inputs.app-name }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+            URL="http://$URL"
+          elif [ "${{ inputs.deployment-type }}" == "storage" ]; then
+            URL=$(az storage account show --name ${{ inputs.storage-account }} --query "primaryEndpoints.web" --output tsv)
+          fi
+          echo "url=$URL" >> $GITHUB_OUTPUT
+```
+
+### GCP Deployment Workflow
+
+```yaml
+# .github/workflows/reusable-deploy-gcp.yml
+name: Reusable GCP Deployment
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: true
+        type: string
+      project-id:
+        description: 'GCP project ID'
+        required: true
+        type: string
+      region:
+        description: 'GCP region'
+        required: false
+        type: string
+        default: 'us-central1'
+      deployment-type:
+        description: 'Deployment type (cloudrun, appengine, gke, cloudfunctions, storage)'
+        required: true
+        type: string
+      service-name:
+        description: 'Service/function name'
+        required: true
+        type: string
+      image-uri:
+        description: 'Container image URI'
+        required: false
+        type: string
+        default: ''
+      cluster-name:
+        description: 'GKE cluster name'
+        required: false
+        type: string
+        default: ''
+      bucket-name:
+        description: 'GCS bucket for deployment'
+        required: false
+        type: string
+        default: ''
+      artifact-path:
+        description: 'Path to deployment artifacts'
+        required: false
+        type: string
+        default: 'dist/'
+      min-instances:
+        description: 'Minimum instances'
+        required: false
+        type: number
+        default: 0
+      max-instances:
+        description: 'Maximum instances'
+        required: false
+        type: number
+        default: 100
+    outputs:
+      deployment-url:
+        description: 'Deployment URL'
+        value: ${{ jobs.deploy.outputs.url }}
+    secrets:
+      GCP_CREDENTIALS:
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ inputs.project-id }}
+
+      - name: Download build artifacts
+        if: inputs.deployment-type == 'appengine' || inputs.deployment-type == 'cloudfunctions' || inputs.deployment-type == 'storage'
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: ${{ inputs.artifact-path }}
+
+      - name: Deploy to Cloud Run
+        id: deploy-cloudrun
+        if: inputs.deployment-type == 'cloudrun'
+        run: |
+          gcloud run deploy ${{ inputs.service-name }} \
+            --image ${{ inputs.image-uri }} \
+            --region ${{ inputs.region }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --min-instances ${{ inputs.min-instances }} \
+            --max-instances ${{ inputs.max-instances }}
+
+          URL=$(gcloud run services describe ${{ inputs.service-name }} \
+            --region ${{ inputs.region }} \
+            --format 'value(status.url)')
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Deploy to App Engine
+        id: deploy-appengine
+        if: inputs.deployment-type == 'appengine'
+        working-directory: ${{ inputs.artifact-path }}
+        run: |
+          gcloud app deploy --quiet --promote
+
+          URL="https://${{ inputs.project-id }}.appspot.com"
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Deploy to GKE
+        id: deploy-gke
+        if: inputs.deployment-type == 'gke'
+        run: |
+          gcloud container clusters get-credentials ${{ inputs.cluster-name }} \
+            --region ${{ inputs.region }} \
+            --project ${{ inputs.project-id }}
+
+          kubectl set image deployment/${{ inputs.service-name }} \
+            ${{ inputs.service-name }}=${{ inputs.image-uri }}
+
+          kubectl rollout status deployment/${{ inputs.service-name }} --timeout=5m
+
+          SERVICE_IP=$(kubectl get svc ${{ inputs.service-name }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo "url=http://$SERVICE_IP" >> $GITHUB_OUTPUT
+
+      - name: Deploy Cloud Function
+        id: deploy-function
+        if: inputs.deployment-type == 'cloudfunctions'
+        working-directory: ${{ inputs.artifact-path }}
+        run: |
+          gcloud functions deploy ${{ inputs.service-name }} \
+            --gen2 \
+            --runtime nodejs20 \
+            --region ${{ inputs.region }} \
+            --trigger-http \
+            --allow-unauthenticated \
+            --min-instances ${{ inputs.min-instances }} \
+            --max-instances ${{ inputs.max-instances }}
+
+          URL=$(gcloud functions describe ${{ inputs.service-name }} \
+            --region ${{ inputs.region }} \
+            --gen2 \
+            --format 'value(serviceConfig.uri)')
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Deploy to Cloud Storage
+        id: deploy-storage
+        if: inputs.deployment-type == 'storage'
+        run: |
+          gsutil -m rsync -r -d ${{ inputs.artifact-path }} gs://${{ inputs.bucket-name }}
+
+          gsutil web set -m index.html -e 404.html gs://${{ inputs.bucket-name }}
+
+          echo "url=https://storage.googleapis.com/${{ inputs.bucket-name }}/index.html" >> $GITHUB_OUTPUT
+
+      - name: Set deployment output
+        id: deploy
+        run: |
+          if [ "${{ inputs.deployment-type }}" == "cloudrun" ]; then
+            echo "url=${{ steps.deploy-cloudrun.outputs.url }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.deployment-type }}" == "appengine" ]; then
+            echo "url=${{ steps.deploy-appengine.outputs.url }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.deployment-type }}" == "gke" ]; then
+            echo "url=${{ steps.deploy-gke.outputs.url }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.deployment-type }}" == "cloudfunctions" ]; then
+            echo "url=${{ steps.deploy-function.outputs.url }}" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.deployment-type }}" == "storage" ]; then
+            echo "url=${{ steps.deploy-storage.outputs.url }}" >> $GITHUB_OUTPUT
+          fi
+```
+
+---
+
+## Notification Workflow
+
+### Reusable Notification Workflow
+
+```yaml
+# .github/workflows/reusable-notify.yml
+name: Reusable Notification Workflow
+
+on:
+  workflow_call:
+    inputs:
+      status:
+        description: 'Deployment/build status'
+        required: true
+        type: string
+      environment:
+        description: 'Environment name'
+        required: false
+        type: string
+        default: ''
+      deployment-url:
+        description: 'Deployment URL'
+        required: false
+        type: string
+        default: ''
+      message:
+        description: 'Custom message'
+        required: false
+        type: string
+        default: ''
+      notify-slack:
+        description: 'Send Slack notification'
+        required: false
+        type: boolean
+        default: true
+      notify-teams:
+        description: 'Send Teams notification'
+        required: false
+        type: boolean
+        default: false
+      notify-discord:
+        description: 'Send Discord notification'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false
+      TEAMS_WEBHOOK_URL:
+        required: false
+      DISCORD_WEBHOOK_URL:
+        required: false
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set status emoji
+        id: emoji
+        run: |
+          if [ "${{ inputs.status }}" == "success" ]; then
+            echo "emoji=:white_check_mark:" >> $GITHUB_OUTPUT
+            echo "color=good" >> $GITHUB_OUTPUT
+            echo "teams_color=00FF00" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.status }}" == "failure" ]; then
+            echo "emoji=:x:" >> $GITHUB_OUTPUT
+            echo "color=danger" >> $GITHUB_OUTPUT
+            echo "teams_color=FF0000" >> $GITHUB_OUTPUT
+          else
+            echo "emoji=:warning:" >> $GITHUB_OUTPUT
+            echo "color=warning" >> $GITHUB_OUTPUT
+            echo "teams_color=FFFF00" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Slack notification
+        if: inputs.notify-slack && secrets.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "${{ steps.emoji.outputs.color }}",
+                  "blocks": [
+                    {
+                      "type": "header",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "${{ steps.emoji.outputs.emoji }} ${{ github.repository }} - ${{ inputs.status }}"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Workflow:*\n${{ github.workflow }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Branch:*\n${{ github.ref_name }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Environment:*\n${{ inputs.environment || 'N/A' }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Triggered by:*\n${{ github.actor }}"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "${{ inputs.message || format('Commit: {0}', github.event.head_commit.message) }}"
+                      }
+                    },
+                    {
+                      "type": "actions",
+                      "elements": [
+                        {
+                          "type": "button",
+                          "text": {
+                            "type": "plain_text",
+                            "text": "View Run"
+                          },
+                          "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                        },
+                        {
+                          "type": "button",
+                          "text": {
+                            "type": "plain_text",
+                            "text": "View Deployment"
+                          },
+                          "url": "${{ inputs.deployment-url }}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+
+      - name: Send Teams notification
+        if: inputs.notify-teams && secrets.TEAMS_WEBHOOK_URL != ''
+        run: |
+          curl -H 'Content-Type: application/json' \
+            -d '{
+              "@type": "MessageCard",
+              "@context": "http://schema.org/extensions",
+              "themeColor": "${{ steps.emoji.outputs.teams_color }}",
+              "summary": "${{ github.repository }} - ${{ inputs.status }}",
+              "sections": [{
+                "activityTitle": "${{ github.repository }} - ${{ inputs.status }}",
+                "facts": [
+                  {"name": "Workflow", "value": "${{ github.workflow }}"},
+                  {"name": "Branch", "value": "${{ github.ref_name }}"},
+                  {"name": "Environment", "value": "${{ inputs.environment || 'N/A' }}"},
+                  {"name": "Triggered by", "value": "${{ github.actor }}"}
+                ],
+                "text": "${{ inputs.message || github.event.head_commit.message }}"
+              }],
+              "potentialAction": [
+                {
+                  "@type": "OpenUri",
+                  "name": "View Run",
+                  "targets": [{"os": "default", "uri": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}]
+                }
+              ]
+            }' \
+            ${{ secrets.TEAMS_WEBHOOK_URL }}
+
+      - name: Send Discord notification
+        if: inputs.notify-discord && secrets.DISCORD_WEBHOOK_URL != ''
+        run: |
+          curl -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "${{ github.repository }} - ${{ inputs.status }}",
+                "color": ${{ inputs.status == 'success' && '65280' || inputs.status == 'failure' && '16711680' || '16776960' }},
+                "fields": [
+                  {"name": "Workflow", "value": "${{ github.workflow }}", "inline": true},
+                  {"name": "Branch", "value": "${{ github.ref_name }}", "inline": true},
+                  {"name": "Environment", "value": "${{ inputs.environment || 'N/A' }}", "inline": true},
+                  {"name": "Triggered by", "value": "${{ github.actor }}", "inline": true}
+                ],
+                "description": "${{ inputs.message || github.event.head_commit.message }}",
+                "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              }]
+            }' \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+```
+
+---
+
+## Complete CI/CD Pipeline Example
+
+### Full Pipeline Using Reusable Workflows
+
+```yaml
+# .github/workflows/complete-pipeline.yml
+name: Complete CI/CD Pipeline
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deploy to environment'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Stage 1: Build and Test
+  build:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      language: node
+      node-version: '20'
+      artifact-name: app-build
+    secrets: inherit
+
+  test:
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      language: node
+      node-version: '20'
+      coverage-threshold: 80
+    secrets: inherit
+
+  # Stage 2: Security Scanning
+  security:
+    needs: [build, test]
+    uses: ./.github/workflows/reusable-security.yml
+    with:
+      languages: '["javascript", "typescript"]'
+      scan-dependencies: true
+      scan-secrets: true
+      scan-sast: true
+    secrets: inherit
+
+  # Stage 3: Docker Build
+  docker:
+    needs: [build, test, security]
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/reusable-docker.yml
+    with:
+      image-name: ${{ github.repository }}
+      push: true
+      scan-image: true
+    secrets: inherit
+
+  # Stage 4: Deploy to Staging
+  deploy-staging:
+    needs: docker
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    uses: ./.github/workflows/reusable-deploy-aws.yml
+    with:
+      environment: staging
+      deployment-type: ecs
+      service-name: myapp
+      cluster-name: staging-cluster
+      image-uri: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      health-check-url: https://staging.example.com/health
+    secrets: inherit
+
+  # Stage 5: Integration Tests
+  integration-tests:
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run integration tests
+        run: |
+          npm ci
+          npm run test:integration
+        env:
+          TEST_URL: https://staging.example.com
+
+  # Stage 6: Deploy to Production
+  deploy-production:
+    needs: [integration-tests]
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || inputs.environment == 'production')
+    uses: ./.github/workflows/reusable-deploy-aws.yml
+    with:
+      environment: production
+      deployment-type: ecs
+      service-name: myapp
+      cluster-name: production-cluster
+      image-uri: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      health-check-url: https://example.com/health
+      rollback-on-failure: true
+    secrets: inherit
+
+  # Stage 7: Notifications
+  notify-success:
+    needs: [deploy-staging, deploy-production]
+    if: success()
+    uses: ./.github/workflows/reusable-notify.yml
+    with:
+      status: success
+      environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+      deployment-url: ${{ github.ref == 'refs/heads/main' && 'https://example.com' || 'https://staging.example.com' }}
+      notify-slack: true
+    secrets: inherit
+
+  notify-failure:
+    needs: [build, test, security, docker, deploy-staging, deploy-production]
+    if: failure()
+    uses: ./.github/workflows/reusable-notify.yml
+    with:
+      status: failure
+      message: 'Pipeline failed - please investigate'
+      notify-slack: true
+    secrets: inherit
+```
+
+---
+
+## Best Practices
+
+### Workflow Organization
+
+```text
+.github/
+  workflows/
+    # Reusable workflows (called by others)
+    reusable-build.yml
+    reusable-test.yml
+    reusable-docker.yml
+    reusable-terraform.yml
+    reusable-security.yml
+    reusable-deploy-aws.yml
+    reusable-deploy-azure.yml
+    reusable-deploy-gcp.yml
+    reusable-notify.yml
+
+    # Main workflows (entry points)
+    ci.yml                    # Pull request CI
+    cd.yml                    # Continuous deployment
+    release.yml               # Release workflow
+    scheduled-security.yml    # Scheduled security scans
+```
+
+### Input/Output Design
+
+```yaml
+# Good - Typed inputs with defaults
+inputs:
+  language:
+    description: 'Programming language'
+    required: true
+    type: string
+  version:
+    description: 'Language version'
+    required: false
+    type: string
+    default: 'latest'
+  coverage-threshold:
+    description: 'Minimum coverage'
+    required: false
+    type: number
+    default: 80
+
+# Good - Clear outputs
+outputs:
+  artifact-name:
+    description: 'Name of the uploaded artifact'
+    value: ${{ jobs.build.outputs.artifact }}
+  version:
+    description: 'Built version'
+    value: ${{ jobs.build.outputs.version }}
+```
+
+### Secret Inheritance
+
+```yaml
+# Caller workflow
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit  # Pass all secrets
+
+# Or explicit secrets
+jobs:
+  deploy:
+    uses: ./.github/workflows/reusable-deploy.yml
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+---
+
+## References
+
+- [GitHub Reusable Workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
+- [Workflow Syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)
+- [GitHub Actions Security](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+
+---
+
+**Status**: Active

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,8 @@ nav:
       - IDE Settings: 04_templates/ide_settings_template.md
       - Operational Templates: 04_templates/operational_templates.md
       - ADR Template: 04_templates/adr_template.md
+      - Reusable Workflows: 04_templates/reusable_workflows_template.md
+      - Code Generators: 04_templates/code_generators_template.md
   - Examples:
       - Python Package: 05_examples/python_package_example.md
       - Terraform Module: 05_examples/terraform_module_example.md


### PR DESCRIPTION
## Summary

- Add comprehensive **Reusable GitHub Actions Workflows** template with production-ready workflows for:
  - Build and test (multi-language: Node.js, Python, Go, Rust)
  - Docker build and push with security scanning
  - Terraform with multi-environment support
  - Security scanning (CodeQL, Semgrep, Trivy, dependency review)
  - Cloud deployments (AWS ECS/Lambda/S3/EKS, Azure, GCP)
  - Notifications (Slack, Teams, Discord)
  - Complete CI/CD pipeline example

- Add comprehensive **Code Generators** template covering:
  - **Plop** - React components, API endpoints, database migrations, hooks
  - **Copier** - Python package scaffolding with conditional features
  - **Yeoman** - Full project generators with sub-generators

## Test plan

- [ ] Verify documentation builds successfully with `mkdocs build --strict`
- [ ] Verify new templates appear in navigation under Templates section
- [ ] Review reusable workflows template for completeness
- [ ] Review code generators template for completeness
- [ ] Verify code-to-text ratio meets 3:1 requirement

Closes #284

🤖 Generated with [Claude Code](https://claude.ai/code)