### PR TITLE
feat(docs): add tutorial series for common scenarios (#194)

### DIFF
--- a/docs/12_tutorials/fullstack_app.md
+++ b/docs/12_tutorials/fullstack_app.md
@@ -1,0 +1,3711 @@
+---
+title: "Tutorial 3: Full-Stack App with Multiple Languages"
+description: "Build a monorepo with Python backend, TypeScript frontend, and Terraform infrastructure following the Dukes Engineering Style Guide"
+author: "Tyler Dukes"
+tags: [tutorial, fullstack, python, typescript, terraform, monorepo, docker, ci-cd, fastapi, react]
+category: "Tutorials"
+status: "active"
+---
+
+<!-- markdownlint-disable MD013 -->
+
+## Overview
+
+In this tutorial you will build a **task management application** as a monorepo containing three major components, each following the Dukes Engineering Style Guide conventions for its respective language.
+
+```text
+What You Will Build
+====================
+Component          Language       Framework      Style Guide Section
+---------------------------------------------------------------------------
+Backend API        Python         FastAPI        02_language_guides/python
+Frontend SPA       TypeScript     React          02_language_guides/typescript
+Infrastructure     HCL            Terraform      02_language_guides/terraform
+Containers         Dockerfile     Docker         02_language_guides/docker
+CI/CD Pipeline     YAML           GitHub Actions 02_language_guides/github_actions
+Build Orchestration Makefile      GNU Make       02_language_guides/makefile
+```
+
+```text
+Time Breakdown
+==============
+Step 1: Monorepo Structure ........  5 min
+Step 2: Python Backend ............ 15 min
+Step 3: TypeScript Frontend ....... 15 min
+Step 4: Terraform Infrastructure .. 10 min
+Step 5: Docker Configuration ......  5 min
+Step 6: Monorepo CI/CD ............  8 min
+Step 7: Cross-Language Validation ..  2 min
+                                    -------
+Total                               60 min
+```
+
+### Prerequisites
+
+```bash
+# Verify all prerequisites before starting
+python3 --version    # Python 3.10+
+node --version       # Node.js 20+
+npm --version        # npm 9+
+terraform --version  # Terraform 1.5+
+docker --version     # Docker 20.10+
+git --version        # Git 2.30+
+```
+
+```bash
+# Install uv (Python package manager)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install pre-commit
+pip install pre-commit
+
+# Verify installations
+uv --version
+pre-commit --version
+```
+
+---
+
+## Step 1: Monorepo Structure (5 min)
+
+### Create the directory layout
+
+```bash
+# Create project root
+mkdir -p taskflow && cd taskflow
+git init
+
+# Create full directory structure
+mkdir -p backend/src/models
+mkdir -p backend/src/routes
+mkdir -p backend/src/services
+mkdir -p backend/tests
+mkdir -p frontend/src/components
+mkdir -p frontend/src/hooks
+mkdir -p frontend/src/types
+mkdir -p frontend/src/services
+mkdir -p frontend/public
+mkdir -p infrastructure/modules/ecs
+mkdir -p infrastructure/modules/rds
+mkdir -p infrastructure/modules/networking
+mkdir -p infrastructure/environments/dev
+mkdir -p infrastructure/environments/prod
+mkdir -p shared/schemas
+mkdir -p .github/workflows
+mkdir -p scripts
+```
+
+```bash
+# Verify structure
+tree -L 3 --dirsfirst
+```
+
+```text
+taskflow/
+├── .github/
+│   └── workflows/
+├── backend/
+│   ├── src/
+│   │   ├── models/
+│   │   ├── routes/
+│   │   └── services/
+│   └── tests/
+├── frontend/
+│   ├── public/
+│   └── src/
+│       ├── components/
+│       ├── hooks/
+│       ├── services/
+│       └── types/
+├── infrastructure/
+│   ├── environments/
+│   │   ├── dev/
+│   │   └── prod/
+│   └── modules/
+│       ├── ecs/
+│       ├── networking/
+│       └── rds/
+├── scripts/
+└── shared/
+    └── schemas/
+```
+
+### Root .editorconfig
+
+```ini
+# .editorconfig - Universal editor configuration
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+[*.{ts,tsx,js,jsx,json}]
+indent_style = space
+indent_size = 2
+
+[*.{tf,tfvars}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[Dockerfile]
+indent_style = space
+indent_size = 4
+```
+
+### Root .pre-commit-config.yaml
+
+```yaml
+# .pre-commit-config.yaml - Multi-language pre-commit hooks
+repos:
+  # -- General file checks --
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ["--unsafe"]
+      - id: check-json
+      - id: check-added-large-files
+        args: ["--maxkb=1000"]
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending
+
+  # -- Python hooks --
+  - repo: https://github.com/psf/black
+    rev: "25.1.0"
+    hooks:
+      - id: black
+        args: ["--line-length=100"]
+        files: ^backend/
+
+  - repo: https://github.com/pycqa/flake8
+    rev: "7.1.2"
+    hooks:
+      - id: flake8
+        args: ["--max-line-length=100", "--extend-ignore=E203,W503"]
+        files: ^backend/
+
+  # -- TypeScript/JavaScript hooks --
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.20.0
+    hooks:
+      - id: eslint
+        files: ^frontend/.*\.[jt]sx?$
+        additional_dependencies:
+          - eslint@9.20.0
+          - typescript@5.7.3
+          - "@typescript-eslint/parser@8.24.0"
+          - "@typescript-eslint/eslint-plugin@8.24.0"
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        files: ^frontend/
+        types_or: [javascript, jsx, ts, tsx, json, css]
+
+  # -- Terraform hooks --
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.97.4
+    hooks:
+      - id: terraform_fmt
+        files: ^infrastructure/
+      - id: terraform_validate
+        files: ^infrastructure/
+      - id: terraform_docs
+        files: ^infrastructure/
+
+  # -- Shell hooks --
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        files: ^scripts/
+
+  # -- Markdown hooks --
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+      - id: markdownlint
+        args: ["--fix"]
+
+  # -- YAML hooks --
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: ["-d", "{extends: default, rules: {line-length: {max: 120}, document-start: disable}}"]
+```
+
+### Root Makefile
+
+```makefile
+# Makefile - Monorepo build orchestration
+#
+# @module taskflow_makefile
+# @description Root Makefile for multi-language monorepo build and validation
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+
+# ============================================================================
+# Variables
+# ============================================================================
+
+BACKEND_DIR     := backend
+FRONTEND_DIR    := frontend
+INFRA_DIR       := infrastructure
+DOCKER_COMPOSE  := docker compose
+
+# ============================================================================
+# Help
+# ============================================================================
+
+.PHONY: help
+help: ## Show this help message
+  @echo "TaskFlow Monorepo Commands"
+  @echo "========================="
+  @grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+    awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# ============================================================================
+# Setup
+# ============================================================================
+
+.PHONY: setup
+setup: setup-backend setup-frontend setup-hooks ## Set up all components
+
+.PHONY: setup-backend
+setup-backend: ## Set up Python backend
+  cd $(BACKEND_DIR) && uv sync
+
+.PHONY: setup-frontend
+setup-frontend: ## Set up TypeScript frontend
+  cd $(FRONTEND_DIR) && npm ci
+
+.PHONY: setup-hooks
+setup-hooks: ## Install pre-commit hooks
+  pre-commit install --install-hooks
+
+# ============================================================================
+# Development
+# ============================================================================
+
+.PHONY: dev
+dev: ## Start all services in development mode
+  $(DOCKER_COMPOSE) up --build
+
+.PHONY: dev-backend
+dev-backend: ## Start backend only
+  cd $(BACKEND_DIR) && uv run uvicorn src.main:app --reload --port 8000
+
+.PHONY: dev-frontend
+dev-frontend: ## Start frontend only
+  cd $(FRONTEND_DIR) && npm run dev
+
+# ============================================================================
+# Testing
+# ============================================================================
+
+.PHONY: test
+test: test-backend test-frontend ## Run all tests
+
+.PHONY: test-backend
+test-backend: ## Run Python backend tests
+  cd $(BACKEND_DIR) && uv run pytest tests/ -v --cov=src --cov-report=term-missing
+
+.PHONY: test-frontend
+test-frontend: ## Run TypeScript frontend tests
+  cd $(FRONTEND_DIR) && npm test -- --coverage
+
+# ============================================================================
+# Linting and Formatting
+# ============================================================================
+
+.PHONY: lint
+lint: lint-backend lint-frontend lint-infra ## Lint all components
+
+.PHONY: lint-backend
+lint-backend: ## Lint Python backend
+  cd $(BACKEND_DIR) && uv run black --check src/ tests/
+  cd $(BACKEND_DIR) && uv run flake8 src/ tests/
+
+.PHONY: lint-frontend
+lint-frontend: ## Lint TypeScript frontend
+  cd $(FRONTEND_DIR) && npm run lint
+  cd $(FRONTEND_DIR) && npm run format:check
+
+.PHONY: lint-infra
+lint-infra: ## Lint Terraform infrastructure
+  cd $(INFRA_DIR) && terraform fmt -check -recursive
+
+.PHONY: format
+format: format-backend format-frontend format-infra ## Format all components
+
+.PHONY: format-backend
+format-backend: ## Format Python backend
+  cd $(BACKEND_DIR) && uv run black src/ tests/
+
+.PHONY: format-frontend
+format-frontend: ## Format TypeScript frontend
+  cd $(FRONTEND_DIR) && npm run format
+
+.PHONY: format-infra
+format-infra: ## Format Terraform infrastructure
+  cd $(INFRA_DIR) && terraform fmt -recursive
+
+# ============================================================================
+# Infrastructure
+# ============================================================================
+
+.PHONY: infra-init
+infra-init: ## Initialize Terraform
+  cd $(INFRA_DIR)/environments/dev && terraform init
+
+.PHONY: infra-plan
+infra-plan: ## Plan Terraform changes
+  cd $(INFRA_DIR)/environments/dev && terraform plan -out=tfplan
+
+.PHONY: infra-apply
+infra-apply: ## Apply Terraform changes
+  cd $(INFRA_DIR)/environments/dev && terraform apply tfplan
+
+# ============================================================================
+# Docker
+# ============================================================================
+
+.PHONY: docker-build
+docker-build: ## Build all Docker images
+  $(DOCKER_COMPOSE) build
+
+.PHONY: docker-up
+docker-up: ## Start all containers
+  $(DOCKER_COMPOSE) up -d
+
+.PHONY: docker-down
+docker-down: ## Stop all containers
+  $(DOCKER_COMPOSE) down
+
+# ============================================================================
+# Validation (CI)
+# ============================================================================
+
+.PHONY: validate
+validate: lint test ## Run full validation suite
+  @echo "All validations passed."
+
+.PHONY: pre-commit
+pre-commit: ## Run pre-commit on all files
+  pre-commit run --all-files
+
+# ============================================================================
+# Clean
+# ============================================================================
+
+.PHONY: clean
+clean: ## Remove build artifacts and caches
+  rm -rf $(BACKEND_DIR)/.pytest_cache
+  rm -rf $(BACKEND_DIR)/src/__pycache__
+  rm -rf $(BACKEND_DIR)/.coverage
+  rm -rf $(FRONTEND_DIR)/node_modules
+  rm -rf $(FRONTEND_DIR)/build
+  $(DOCKER_COMPOSE) down --rmi local --volumes --remove-orphans
+```
+
+### Checkpoint: Monorepo structure
+
+```bash
+# Verify all root config files exist
+ls -la .editorconfig .pre-commit-config.yaml Makefile
+
+# Verify directory structure
+test -d backend/src/models && echo "PASS: backend structure"
+test -d frontend/src/components && echo "PASS: frontend structure"
+test -d infrastructure/modules/ecs && echo "PASS: infrastructure structure"
+test -d .github/workflows && echo "PASS: workflows directory"
+
+# Initialize pre-commit
+pre-commit install --install-hooks
+```
+
+---
+
+## Step 2: Python Backend (15 min)
+
+### backend/pyproject.toml
+
+```toml
+[project]
+name = "taskflow-backend"
+version = "1.0.0"
+description = "TaskFlow API - FastAPI backend for task management"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+    "pydantic>=2.10.0",
+    "sqlalchemy>=2.0.0",
+    "asyncpg>=0.30.0",
+    "alembic>=1.14.0",
+    "python-dotenv>=1.0.0",
+    "httpx>=0.28.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3.0",
+    "pytest-asyncio>=0.25.0",
+    "pytest-cov>=6.0.0",
+    "black>=25.1.0",
+    "flake8>=7.1.0",
+    "mypy>=1.14.0",
+    "httpx>=0.28.0",
+]
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = "-v --tb=short"
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+
+[tool.coverage.run]
+source = ["src"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+```
+
+### backend/src/\_\_init\_\_.py
+
+```python
+"""
+@module taskflow_backend
+@description FastAPI backend for TaskFlow task management application
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+```
+
+### backend/src/models/task.py
+
+```python
+"""
+@module task_models
+@description Pydantic models for task CRUD operations with full type safety
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class TaskStatus(str, Enum):
+    """Valid task status values."""
+
+    TODO = "todo"
+    IN_PROGRESS = "in_progress"
+    DONE = "done"
+    ARCHIVED = "archived"
+
+
+class TaskPriority(str, Enum):
+    """Valid task priority values."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class TaskBase(BaseModel):
+    """Shared fields for task creation and updates."""
+
+    title: str = Field(
+        ...,
+        min_length=1,
+        max_length=200,
+        description="Task title",
+        examples=["Implement user authentication"],
+    )
+    description: Optional[str] = Field(
+        None,
+        max_length=2000,
+        description="Detailed task description",
+    )
+    status: TaskStatus = Field(
+        default=TaskStatus.TODO,
+        description="Current task status",
+    )
+    priority: TaskPriority = Field(
+        default=TaskPriority.MEDIUM,
+        description="Task priority level",
+    )
+    assignee: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="Assigned team member",
+    )
+
+    @field_validator("title")
+    @classmethod
+    def title_must_not_be_blank(cls, v: str) -> str:
+        """Validate that title is not whitespace-only."""
+        if not v.strip():
+            raise ValueError("Title must contain non-whitespace characters")
+        return v.strip()
+
+
+class TaskCreate(TaskBase):
+    """Request model for creating a new task."""
+
+    pass
+
+
+class TaskUpdate(BaseModel):
+    """Request model for partial task updates."""
+
+    title: Optional[str] = Field(None, min_length=1, max_length=200)
+    description: Optional[str] = Field(None, max_length=2000)
+    status: Optional[TaskStatus] = None
+    priority: Optional[TaskPriority] = None
+    assignee: Optional[str] = Field(None, max_length=100)
+
+
+class TaskResponse(TaskBase):
+    """Response model returned to API clients."""
+
+    id: UUID = Field(default_factory=uuid4, description="Unique task identifier")
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Timestamp of creation",
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Timestamp of last update",
+    )
+
+    model_config = {"from_attributes": True}
+
+
+class TaskListResponse(BaseModel):
+    """Paginated list response for tasks."""
+
+    tasks: list[TaskResponse]
+    total: int = Field(description="Total number of tasks matching query")
+    page: int = Field(ge=1, description="Current page number")
+    per_page: int = Field(ge=1, le=100, description="Items per page")
+
+    @property
+    def total_pages(self) -> int:
+        """Calculate total number of pages."""
+        return (self.total + self.per_page - 1) // self.per_page
+```
+
+### backend/src/main.py
+
+```python
+"""
+@module taskflow_api
+@description FastAPI application entry point with health check and CORS configuration
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import AsyncGenerator
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from src.routes.tasks import router as tasks_router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Application lifespan handler for startup and shutdown events."""
+    # -- Startup --
+    print("TaskFlow API starting up...")
+    yield
+    # -- Shutdown --
+    print("TaskFlow API shutting down...")
+
+
+app = FastAPI(
+    title="TaskFlow API",
+    description="Task management API built with the Dukes Engineering Style Guide",
+    version="1.0.0",
+    lifespan=lifespan,
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+
+# -- CORS Configuration --
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:3000",
+        "http://localhost:5173",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# -- Router Registration --
+app.include_router(tasks_router, prefix="/api/v1")
+
+
+@app.get("/health", tags=["health"])
+async def health_check() -> dict[str, str]:
+    """Health check endpoint for load balancer and container orchestration probes.
+
+    Returns:
+        dict: Health status with service name and timestamp.
+    """
+    return {
+        "status": "healthy",
+        "service": "taskflow-api",
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+
+
+@app.get("/ready", tags=["health"])
+async def readiness_check() -> dict[str, str]:
+    """Readiness check endpoint for Kubernetes and ECS readiness probes.
+
+    Returns:
+        dict: Readiness status.
+    """
+    # In production, check database connectivity here
+    return {
+        "status": "ready",
+        "service": "taskflow-api",
+    }
+```
+
+### backend/src/routes/\_\_init\_\_.py
+
+```python
+"""
+@module taskflow_routes
+@description API route modules for TaskFlow backend
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+```
+
+### backend/src/routes/tasks.py
+
+```python
+"""
+@module task_routes
+@description CRUD API routes for task management with proper error handling
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.models.task import (
+    TaskCreate,
+    TaskListResponse,
+    TaskPriority,
+    TaskResponse,
+    TaskStatus,
+    TaskUpdate,
+)
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+# -- In-memory store (replace with database in production) --
+_task_store: dict[UUID, TaskResponse] = {}
+
+
+@router.post(
+    "/",
+    response_model=TaskResponse,
+    status_code=201,
+    summary="Create a new task",
+)
+async def create_task(task: TaskCreate) -> TaskResponse:
+    """Create a new task with the provided details.
+
+    Args:
+        task: Task creation payload with title, description, status, and priority.
+
+    Returns:
+        TaskResponse: The newly created task with generated ID and timestamps.
+    """
+    now = datetime.utcnow()
+    task_response = TaskResponse(
+        id=uuid4(),
+        title=task.title,
+        description=task.description,
+        status=task.status,
+        priority=task.priority,
+        assignee=task.assignee,
+        created_at=now,
+        updated_at=now,
+    )
+    _task_store[task_response.id] = task_response
+    return task_response
+
+
+@router.get(
+    "/",
+    response_model=TaskListResponse,
+    summary="List tasks with pagination and filtering",
+)
+async def list_tasks(
+    page: int = Query(1, ge=1, description="Page number"),
+    per_page: int = Query(20, ge=1, le=100, description="Items per page"),
+    status: Optional[TaskStatus] = Query(None, description="Filter by status"),
+    priority: Optional[TaskPriority] = Query(None, description="Filter by priority"),
+    assignee: Optional[str] = Query(None, description="Filter by assignee"),
+) -> TaskListResponse:
+    """List all tasks with optional filtering and pagination.
+
+    Args:
+        page: Page number (1-indexed).
+        per_page: Number of items per page (max 100).
+        status: Optional status filter.
+        priority: Optional priority filter.
+        assignee: Optional assignee filter.
+
+    Returns:
+        TaskListResponse: Paginated list of tasks matching filters.
+    """
+    tasks = list(_task_store.values())
+
+    # -- Apply filters --
+    if status is not None:
+        tasks = [t for t in tasks if t.status == status]
+    if priority is not None:
+        tasks = [t for t in tasks if t.priority == priority]
+    if assignee is not None:
+        tasks = [t for t in tasks if t.assignee == assignee]
+
+    # -- Apply pagination --
+    total = len(tasks)
+    start = (page - 1) * per_page
+    end = start + per_page
+    paginated_tasks = tasks[start:end]
+
+    return TaskListResponse(
+        tasks=paginated_tasks,
+        total=total,
+        page=page,
+        per_page=per_page,
+    )
+
+
+@router.get(
+    "/{task_id}",
+    response_model=TaskResponse,
+    summary="Get a task by ID",
+)
+async def get_task(task_id: UUID) -> TaskResponse:
+    """Retrieve a single task by its UUID.
+
+    Args:
+        task_id: The unique identifier of the task.
+
+    Returns:
+        TaskResponse: The requested task.
+
+    Raises:
+        HTTPException: 404 if task not found.
+    """
+    task = _task_store.get(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+    return task
+
+
+@router.patch(
+    "/{task_id}",
+    response_model=TaskResponse,
+    summary="Update a task",
+)
+async def update_task(task_id: UUID, task_update: TaskUpdate) -> TaskResponse:
+    """Update an existing task with partial data.
+
+    Args:
+        task_id: The unique identifier of the task to update.
+        task_update: Partial update payload (only provided fields are changed).
+
+    Returns:
+        TaskResponse: The updated task.
+
+    Raises:
+        HTTPException: 404 if task not found.
+    """
+    existing = _task_store.get(task_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+
+    update_data = task_update.model_dump(exclude_unset=True)
+    updated_task = existing.model_copy(
+        update={
+            **update_data,
+            "updated_at": datetime.utcnow(),
+        }
+    )
+    _task_store[task_id] = updated_task
+    return updated_task
+
+
+@router.delete(
+    "/{task_id}",
+    status_code=204,
+    summary="Delete a task",
+)
+async def delete_task(task_id: UUID) -> None:
+    """Delete a task by its UUID.
+
+    Args:
+        task_id: The unique identifier of the task to delete.
+
+    Raises:
+        HTTPException: 404 if task not found.
+    """
+    if task_id not in _task_store:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+    del _task_store[task_id]
+```
+
+### backend/src/models/\_\_init\_\_.py
+
+```python
+"""
+@module taskflow_models
+@description Data models for TaskFlow backend
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+```
+
+### backend/src/services/\_\_init\_\_.py
+
+```python
+"""
+@module taskflow_services
+@description Business logic services for TaskFlow backend
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+```
+
+### backend/tests/conftest.py
+
+```python
+"""
+@module test_conftest
+@description Shared test fixtures for TaskFlow backend tests
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
+
+from src.main import app
+from src.routes.tasks import _task_store
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Provide a synchronous test client for the FastAPI application."""
+    _task_store.clear()
+    return TestClient(app)
+
+
+@pytest.fixture
+async def async_client() -> AsyncClient:
+    """Provide an asynchronous test client for the FastAPI application."""
+    _task_store.clear()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+def sample_task_payload() -> dict:
+    """Provide a valid task creation payload for testing."""
+    return {
+        "title": "Implement user authentication",
+        "description": "Add JWT-based auth with refresh tokens",
+        "status": "todo",
+        "priority": "high",
+        "assignee": "tdukes",
+    }
+
+
+@pytest.fixture
+def sample_tasks_batch() -> list[dict]:
+    """Provide a batch of task creation payloads for pagination tests."""
+    return [
+        {
+            "title": f"Task {i}",
+            "description": f"Description for task {i}",
+            "status": "todo",
+            "priority": "medium",
+        }
+        for i in range(25)
+    ]
+```
+
+### backend/tests/test_health.py
+
+```python
+"""
+@module test_health
+@description Tests for health and readiness endpoints
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_health_check_returns_healthy(client: TestClient) -> None:
+    """Health endpoint should return 200 with healthy status."""
+    response = client.get("/health")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert data["service"] == "taskflow-api"
+    assert "timestamp" in data
+
+
+def test_readiness_check_returns_ready(client: TestClient) -> None:
+    """Readiness endpoint should return 200 with ready status."""
+    response = client.get("/ready")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["status"] == "ready"
+    assert data["service"] == "taskflow-api"
+```
+
+### backend/tests/test_tasks.py
+
+```python
+"""
+@module test_tasks
+@description Tests for task CRUD API routes
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-01-15
+@status stable
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_create_task(client: TestClient, sample_task_payload: dict) -> None:
+    """POST /api/v1/tasks should create a task and return 201."""
+    response = client.post("/api/v1/tasks/", json=sample_task_payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["title"] == sample_task_payload["title"]
+    assert data["status"] == "todo"
+    assert data["priority"] == "high"
+    assert "id" in data
+    assert "created_at" in data
+
+
+def test_create_task_validates_blank_title(client: TestClient) -> None:
+    """POST /api/v1/tasks should reject blank titles with 422."""
+    response = client.post("/api/v1/tasks/", json={"title": "   "})
+    assert response.status_code == 422
+
+
+def test_list_tasks_empty(client: TestClient) -> None:
+    """GET /api/v1/tasks should return empty list when no tasks exist."""
+    response = client.get("/api/v1/tasks/")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["tasks"] == []
+    assert data["total"] == 0
+
+
+def test_list_tasks_with_pagination(
+    client: TestClient, sample_tasks_batch: list[dict]
+) -> None:
+    """GET /api/v1/tasks should paginate results correctly."""
+    for payload in sample_tasks_batch:
+        client.post("/api/v1/tasks/", json=payload)
+
+    response = client.get("/api/v1/tasks/?page=1&per_page=10")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["tasks"]) == 10
+    assert data["total"] == 25
+    assert data["page"] == 1
+    assert data["per_page"] == 10
+
+
+def test_list_tasks_filter_by_status(
+    client: TestClient, sample_task_payload: dict
+) -> None:
+    """GET /api/v1/tasks should filter by status parameter."""
+    client.post("/api/v1/tasks/", json=sample_task_payload)
+    client.post(
+        "/api/v1/tasks/",
+        json={**sample_task_payload, "title": "Done task", "status": "done"},
+    )
+
+    response = client.get("/api/v1/tasks/?status=done")
+    data = response.json()
+    assert data["total"] == 1
+    assert data["tasks"][0]["status"] == "done"
+
+
+def test_get_task_by_id(client: TestClient, sample_task_payload: dict) -> None:
+    """GET /api/v1/tasks/{id} should return the specified task."""
+    create_response = client.post("/api/v1/tasks/", json=sample_task_payload)
+    task_id = create_response.json()["id"]
+
+    response = client.get(f"/api/v1/tasks/{task_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == task_id
+
+
+def test_get_task_not_found(client: TestClient) -> None:
+    """GET /api/v1/tasks/{id} should return 404 for missing tasks."""
+    response = client.get("/api/v1/tasks/00000000-0000-0000-0000-000000000000")
+    assert response.status_code == 404
+
+
+def test_update_task(client: TestClient, sample_task_payload: dict) -> None:
+    """PATCH /api/v1/tasks/{id} should partially update a task."""
+    create_response = client.post("/api/v1/tasks/", json=sample_task_payload)
+    task_id = create_response.json()["id"]
+
+    response = client.patch(
+        f"/api/v1/tasks/{task_id}",
+        json={"status": "in_progress", "priority": "critical"},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["status"] == "in_progress"
+    assert data["priority"] == "critical"
+    assert data["title"] == sample_task_payload["title"]
+
+
+def test_delete_task(client: TestClient, sample_task_payload: dict) -> None:
+    """DELETE /api/v1/tasks/{id} should remove the task and return 204."""
+    create_response = client.post("/api/v1/tasks/", json=sample_task_payload)
+    task_id = create_response.json()["id"]
+
+    delete_response = client.delete(f"/api/v1/tasks/{task_id}")
+    assert delete_response.status_code == 204
+
+    get_response = client.get(f"/api/v1/tasks/{task_id}")
+    assert get_response.status_code == 404
+
+
+def test_delete_task_not_found(client: TestClient) -> None:
+    """DELETE /api/v1/tasks/{id} should return 404 for missing tasks."""
+    response = client.delete("/api/v1/tasks/00000000-0000-0000-0000-000000000000")
+    assert response.status_code == 404
+```
+
+### Checkpoint: Backend validation
+
+```bash
+# Navigate to backend and install
+cd backend
+uv sync
+
+# Run linters
+uv run black --check src/ tests/
+uv run flake8 src/ tests/
+
+# Run type checker
+uv run mypy src/
+
+# Run tests
+uv run pytest tests/ -v --cov=src --cov-report=term-missing
+
+# Expected output:
+# tests/test_health.py::test_health_check_returns_healthy PASSED
+# tests/test_health.py::test_readiness_check_returns_ready PASSED
+# tests/test_tasks.py::test_create_task PASSED
+# tests/test_tasks.py::test_create_task_validates_blank_title PASSED
+# tests/test_tasks.py::test_list_tasks_empty PASSED
+# tests/test_tasks.py::test_list_tasks_with_pagination PASSED
+# tests/test_tasks.py::test_list_tasks_filter_by_status PASSED
+# tests/test_tasks.py::test_get_task_by_id PASSED
+# tests/test_tasks.py::test_get_task_not_found PASSED
+# tests/test_tasks.py::test_update_task PASSED
+# tests/test_tasks.py::test_delete_task PASSED
+# tests/test_tasks.py::test_delete_task_not_found PASSED
+#
+# ---------- coverage: 80%+ ----------
+```
+
+---
+
+## Step 3: TypeScript Frontend (15 min)
+
+### frontend/package.json
+
+```json
+{
+  "name": "taskflow-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write 'src/**/*.{ts,tsx,css,json}'",
+    "format:check": "prettier --check 'src/**/*.{ts,tsx,css,json}'",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.2.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.24.0",
+    "@typescript-eslint/parser": "^8.24.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "eslint": "^9.20.0",
+    "eslint-config-prettier": "^10.0.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "jsdom": "^26.0.0",
+    "prettier": "^3.5.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.1.0",
+    "vitest": "^3.0.0"
+  }
+}
+```
+
+### frontend/tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+### frontend/.prettierrc
+
+```json
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}
+```
+
+### frontend/src/types/task.ts
+
+```typescript
+/**
+ * @module task_types
+ * @description TypeScript type definitions for the TaskFlow API
+ * @version 1.0.0
+ * @author Tyler Dukes
+ * @last_updated 2025-01-15
+ * @status stable
+ */
+
+/** Valid task status values matching the backend enum. */
+export type TaskStatus = 'todo' | 'in_progress' | 'done' | 'archived';
+
+/** Valid task priority values matching the backend enum. */
+export type TaskPriority = 'low' | 'medium' | 'high' | 'critical';
+
+/** Task entity returned from the API. */
+export interface Task {
+  readonly id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  assignee: string | null;
+  readonly created_at: string;
+  readonly updated_at: string;
+}
+
+/** Payload for creating a new task. */
+export interface CreateTaskPayload {
+  title: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assignee?: string;
+}
+
+/** Payload for updating an existing task (all fields optional). */
+export interface UpdateTaskPayload {
+  title?: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assignee?: string;
+}
+
+/** Paginated task list response from the API. */
+export interface TaskListResponse {
+  tasks: Task[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+/** Query parameters for listing tasks. */
+export interface TaskListParams {
+  page?: number;
+  per_page?: number;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assignee?: string;
+}
+
+/** Map of priority values to display labels. */
+export const PRIORITY_LABELS: Record<TaskPriority, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  critical: 'Critical',
+};
+
+/** Map of status values to display labels. */
+export const STATUS_LABELS: Record<TaskStatus, string> = {
+  todo: 'To Do',
+  in_progress: 'In Progress',
+  done: 'Done',
+  archived: 'Archived',
+};
+```
+
+### frontend/src/services/api.ts
+
+```typescript
+/**
+ * @module api_client
+ * @description Typed HTTP client for TaskFlow API with error handling
+ * @version 1.0.0
+ * @author Tyler Dukes
+ * @last_updated 2025-01-15
+ * @status stable
+ */
+
+import type {
+  CreateTaskPayload,
+  Task,
+  TaskListParams,
+  TaskListResponse,
+  UpdateTaskPayload,
+} from '../types/task';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000/api/v1';
+
+/** Custom error class for API responses. */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly detail?: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+/**
+ * Generic fetch wrapper with typed response and error handling.
+ *
+ * @param path - API path relative to base URL
+ * @param options - Fetch options
+ * @returns Parsed JSON response
+ * @throws ApiError on non-2xx responses
+ */
+async function fetchApi<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const url = `${API_BASE_URL}${path}`;
+
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => null);
+    throw new ApiError(
+      `API request failed: ${response.status}`,
+      response.status,
+      errorBody?.detail ?? response.statusText,
+    );
+  }
+
+  // Handle 204 No Content
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/** TaskFlow API client with typed methods for all CRUD operations. */
+export const taskApi = {
+  /**
+   * List tasks with optional filtering and pagination.
+   *
+   * @param params - Query parameters for filtering and pagination
+   * @returns Paginated list of tasks
+   */
+  async list(params: TaskListParams = {}): Promise<TaskListResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (params.page !== undefined) searchParams.set('page', String(params.page));
+    if (params.per_page !== undefined) searchParams.set('per_page', String(params.per_page));
+    if (params.status !== undefined) searchParams.set('status', params.status);
+    if (params.priority !== undefined) searchParams.set('priority', params.priority);
+    if (params.assignee !== undefined) searchParams.set('assignee', params.assignee);
+
+    const query = searchParams.toString();
+    return fetchApi<TaskListResponse>(`/tasks/${query ? `?${query}` : ''}`);
+  },
+
+  /**
+   * Get a single task by ID.
+   *
+   * @param id - Task UUID
+   * @returns The requested task
+   */
+  async get(id: string): Promise<Task> {
+    return fetchApi<Task>(`/tasks/${id}`);
+  },
+
+  /**
+   * Create a new task.
+   *
+   * @param payload - Task creation data
+   * @returns The newly created task
+   */
+  async create(payload: CreateTaskPayload): Promise<Task> {
+    return fetchApi<Task>('/tasks/', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  /**
+   * Update an existing task.
+   *
+   * @param id - Task UUID
+   * @param payload - Partial update data
+   * @returns The updated task
+   */
+  async update(id: string, payload: UpdateTaskPayload): Promise<Task> {
+    return fetchApi<Task>(`/tasks/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  /**
+   * Delete a task by ID.
+   *
+   * @param id - Task UUID
+   */
+  async delete(id: string): Promise<void> {
+    await fetchApi<void>(`/tasks/${id}`, { method: 'DELETE' });
+  },
+};
+```
+
+### frontend/src/hooks/useTasks.ts
+
+```typescript
+/**
+ * @module use_tasks_hook
+ * @description React hook for task CRUD operations with loading and error state
+ * @version 1.0.0
+ * @author Tyler Dukes
+ * @last_updated 2025-01-15
+ * @status stable
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { ApiError, taskApi } from '../services/api';
+import type { CreateTaskPayload, Task, TaskListParams, UpdateTaskPayload } from '../types/task';
+
+interface UseTasksState {
+  tasks: Task[];
+  total: number;
+  loading: boolean;
+  error: string | null;
+}
+
+interface UseTasksReturn extends UseTasksState {
+  refresh: () => Promise<void>;
+  createTask: (payload: CreateTaskPayload) => Promise<Task | null>;
+  updateTask: (id: string, payload: UpdateTaskPayload) => Promise<Task | null>;
+  deleteTask: (id: string) => Promise<boolean>;
+}
+
+/**
+ * Custom hook for managing task state and API operations.
+ *
+ * @param params - Optional query parameters for task list
+ * @returns Task state and CRUD operation functions
+ */
+export function useTasks(params: TaskListParams = {}): UseTasksReturn {
+  const [state, setState] = useState<UseTasksState>({
+    tasks: [],
+    total: 0,
+    loading: true,
+    error: null,
+  });
+
+  const refresh = useCallback(async () => {
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const response = await taskApi.list(params);
+      setState({
+        tasks: response.tasks,
+        total: response.total,
+        loading: false,
+        error: null,
+      });
+    } catch (err) {
+      const message = err instanceof ApiError ? err.detail ?? err.message : 'Failed to load tasks';
+      setState((prev) => ({ ...prev, loading: false, error: message }));
+    }
+  }, [params.page, params.per_page, params.status, params.priority, params.assignee]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const createTask = useCallback(
+    async (payload: CreateTaskPayload): Promise<Task | null> => {
+      try {
+        const task = await taskApi.create(payload);
+        await refresh();
+        return task;
+      } catch (err) {
+        const message =
+          err instanceof ApiError ? err.detail ?? err.message : 'Failed to create task';
+        setState((prev) => ({ ...prev, error: message }));
+        return null;
+      }
+    },
+    [refresh],
+  );
+
+  const updateTask = useCallback(
+    async (id: string, payload: UpdateTaskPayload): Promise<Task | null> => {
+      try {
+        const task = await taskApi.update(id, payload);
+        await refresh();
+        return task;
+      } catch (err) {
+        const message =
+          err instanceof ApiError ? err.detail ?? err.message : 'Failed to update task';
+        setState((prev) => ({ ...prev, error: message }));
+        return null;
+      }
+    },
+    [refresh],
+  );
+
+  const deleteTask = useCallback(
+    async (id: string): Promise<boolean> => {
+      try {
+        await taskApi.delete(id);
+        await refresh();
+        return true;
+      } catch (err) {
+        const message =
+          err instanceof ApiError ? err.detail ?? err.message : 'Failed to delete task';
+        setState((prev) => ({ ...prev, error: message }));
+        return false;
+      }
+    },
+    [refresh],
+  );
+
+  return {
+    ...state,
+    refresh,
+    createTask,
+    updateTask,
+    deleteTask,
+  };
+}
+```
+
+### frontend/src/components/TaskList.tsx
+
+```typescript
+/**
+ * @module task_list_component
+ * @description Task list component with filtering and status management
+ * @version 1.0.0
+ * @author Tyler Dukes
+ * @last_updated 2025-01-15
+ * @status stable
+ */
+
+import type { Task, TaskStatus } from '../types/task';
+import { PRIORITY_LABELS, STATUS_LABELS } from '../types/task';
+
+interface TaskListProps {
+  readonly tasks: Task[];
+  readonly onStatusChange: (id: string, status: TaskStatus) => void;
+  readonly onDelete: (id: string) => void;
+}
+
+/** Priority badge color mapping for visual distinction. */
+const PRIORITY_COLORS: Record<string, string> = {
+  low: '#4caf50',
+  medium: '#ff9800',
+  high: '#f44336',
+  critical: '#9c27b0',
+};
+
+export function TaskList({ tasks, onStatusChange, onDelete }: TaskListProps): JSX.Element {
+  if (tasks.length === 0) {
+    return (
+      <div className="task-list-empty">
+        <p>No tasks found. Create one to get started.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="task-list">
+      {tasks.map((task) => (
+        <div key={task.id} className="task-card" data-priority={task.priority}>
+          <div className="task-header">
+            <h3 className="task-title">{task.title}</h3>
+            <span
+              className="priority-badge"
+              style={{ backgroundColor: PRIORITY_COLORS[task.priority] }}
+            >
+              {PRIORITY_LABELS[task.priority]}
+            </span>
+          </div>
+
+          {task.description && <p className="task-description">{task.description}</p>}
+
+          <div className="task-meta">
+            {task.assignee && <span className="task-assignee">@{task.assignee}</span>}
+            <span className="task-date">
+              {new Date(task.created_at).toLocaleDateString()}
+            </span>
+          </div>
+
+          <div className="task-actions">
+            <select
+              value={task.status}
+              onChange={(e) => onStatusChange(task.id, e.target.value as TaskStatus)}
+              className="status-select"
+            >
+              {Object.entries(STATUS_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+
+            <button
+              type="button"
+              onClick={() => onDelete(task.id)}
+              className="delete-button"
+              aria-label={`Delete task: ${task.title}`}
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+### frontend/src/components/TaskForm.tsx
+
+```typescript
+/**
+ * @module task_form_component
+ * @description Form component for creating new tasks with validation
+ * @version 1.0.0
+ * @author Tyler Dukes
+ * @last_updated 2025-01-15
+ * @status stable
+ */
+
+import { useState } from 'react';
+
+import type { CreateTaskPayload, TaskPriority } from '../types/task';
+import { PRIORITY_LABELS } from '../types/task';
+
+interface TaskFormProps {
+  readonly onSubmit: (payload: CreateTaskPayload) => Promise<void>;
+  readonly disabled?: boolean;
+}
+
+export function TaskForm({ onSubmit, disabled = false }: TaskFormProps): JSX.Element {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [priority, setPriority] = useState<TaskPriority>('medium');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+
+    if (!title.trim()) return;
+
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        description: description.trim() || undefined,
+        priority,
+      });
+      // Reset form on success
+      setTitle('');
+      setDescription('');
+      setPriority('medium');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isDisabled = disabled || submitting;
+
+  return (
+    <form onSubmit={handleSubmit} className="task-form">
+      <div className="form-group">
+        <label htmlFor="task-title">Title *</label>
+        <input
+          id="task-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Enter task title"
+          maxLength={200}
+          required
+          disabled={isDisabled}
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="task-description">Description</label>
+        <textarea
+          id="task-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Optional description"
+          maxLength={2000}
+          rows={3}
+          disabled={isDisabled}
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="task-priority">Priority</label>
+        <select
+          id="task-priority"
+          value={priority}
+          onChange={(e) => setPriority(e.target.value as TaskPriority)}
+          disabled={isDisabled}
+        >
+          {Object.entries(PRIORITY_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <button type="submit" disabled={isDisabled || !title.trim()} className="submit-button">
+        {submitting ? 'Creating...' : 'Create Task'}
+      </button>
+    </form>
+  );
+}
+```
+
+### frontend/src/App.tsx
+
+```typescript
+/**
+ * @module taskflow_app
+ * @description Root application component for TaskFlow frontend
+ * @version 1.0.0
+ * @author Tyler Dukes
+ * @last_updated 2025-01-15
+ * @status stable
+ */
+
+import { useState } from 'react';
+
+import { TaskForm } from './components/TaskForm';
+import { TaskList } from './components/TaskList';
+import { useTasks } from './hooks/useTasks';
+import type { CreateTaskPayload, TaskStatus } from './types/task';
+
+export default function App(): JSX.Element {
+  const [statusFilter, setStatusFilter] = useState<TaskStatus | undefined>(undefined);
+
+  const { tasks, total, loading, error, createTask, updateTask, deleteTask } = useTasks({
+    status: statusFilter,
+    per_page: 50,
+  });
+
+  const handleCreate = async (payload: CreateTaskPayload): Promise<void> => {
+    await createTask(payload);
+  };
+
+  const handleStatusChange = async (id: string, status: TaskStatus): Promise<void> => {
+    await updateTask(id, { status });
+  };
+
+  const handleDelete = async (id: string): Promise<void> => {
+    await deleteTask(id);
+  };
+
+  return (
+    <div className="app">
+      <header className="app-header">
+        <h1>TaskFlow</h1>
+        <p className="app-subtitle">Task Management - Dukes Style Guide Demo</p>
+      </header>
+
+      <main className="app-main">
+        <section className="create-section">
+          <h2>New Task</h2>
+          <TaskForm onSubmit={handleCreate} disabled={loading} />
+        </section>
+
+        <section className="list-section">
+          <div className="list-header">
+            <h2>Tasks ({total})</h2>
+            <select
+              value={statusFilter ?? ''}
+              onChange={(e) =>
+                setStatusFilter((e.target.value || undefined) as TaskStatus | undefined)
+              }
+              className="filter-select"
+            >
+              <option value="">All Statuses</option>
+              <option value="todo">To Do</option>
+              <option value="in_progress">In Progress</option>
+              <option value="done">Done</option>
+              <option value="archived">Archived</option>
+            </select>
+          </div>
+
+          {error && <div className="error-banner" role="alert">{error}</div>}
+          {loading && <div className="loading-spinner">Loading...</div>}
+
+          {!loading && (
+            <TaskList
+              tasks={tasks}
+              onStatusChange={handleStatusChange}
+              onDelete={handleDelete}
+            />
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}
+```
+
+### frontend/src/main.tsx
+
+```typescript
+/**
+ * @module taskflow_entry
+ * @description Application entry point that mounts React to the DOM
+ * @version 1.0.0
+ * @author Tyler Dukes
+ * @last_updated 2025-01-15
+ * @status stable
+ */
+
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found. Ensure index.html contains <div id="root"></div>.');
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+```
+
+### Checkpoint: Frontend validation
+
+```bash
+# Navigate to frontend and install
+cd frontend
+npm ci
+
+# Run type checking
+npx tsc --noEmit
+
+# Run linter
+npm run lint
+
+# Run format check
+npm run format:check
+
+# Run tests
+npm test
+
+# Build production bundle
+npm run build
+
+# Expected: All commands exit 0
+```
+
+---
+
+## Step 4: Terraform Infrastructure (10 min)
+
+### infrastructure/modules/ecs/CONTRACT.md
+
+```markdown
+# Module Contract: taskflow-ecs
+
+> **Version**: 1.0.0
+> **Last Updated**: 2025-01-15
+> **Maintained by**: Platform Team
+> **Status**: Active
+
+## 1. Purpose
+
+Provisions an ECS Fargate service with an Application Load Balancer for
+running the TaskFlow application containers. Handles task definitions,
+service discovery, and health check configuration.
+
+## 2. Guarantees
+
+### Resource Guarantees
+
+- **G1**: Creates exactly 1 ECS cluster with Container Insights enabled
+- **G2**: Creates 1 Fargate service with configurable desired count (default: 2)
+- **G3**: Creates 1 ALB with HTTPS listener and health check
+- **G4**: All containers run on Fargate (no EC2 instances)
+- **G5**: Task definition includes CloudWatch log group with 30-day retention
+
+### Security Guarantees
+
+- **G6**: IAM task role follows least-privilege (only specified permissions)
+- **G7**: Security groups restrict inbound to ALB port only
+- **G8**: Container runs as non-root user
+
+### Operational Guarantees
+
+- **G9**: Health check path is configurable (default: /health)
+- **G10**: Rolling deployment with minimum 50% healthy tasks
+
+## 3. Test Mapping
+
+| Guarantee | Test File                    | Test Function              |
+|-----------|------------------------------|----------------------------|
+| G1        | tests/ecs_cluster_test.go    | TestEcsClusterCreation     |
+| G2        | tests/ecs_service_test.go    | TestFargateServiceCount    |
+| G3        | tests/alb_test.go            | TestAlbHealthCheck         |
+| G6        | tests/iam_test.go            | TestTaskRoleLeastPrivilege |
+| G7        | tests/security_test.go       | TestSecurityGroupRules     |
+```
+
+### infrastructure/modules/ecs/variables.tf
+
+```hcl
+# @module taskflow_ecs_variables
+# @description Input variables for the TaskFlow ECS Fargate module
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+variable "project_name" {
+  description = "Project name used for resource naming and tagging"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{2,28}[a-z0-9]$", var.project_name))
+    error_message = "Project name must be 4-30 lowercase alphanumeric characters or hyphens."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "vpc_id" {
+  description = "VPC ID where ECS resources will be deployed"
+  type        = string
+
+  validation {
+    condition     = can(regex("^vpc-[a-f0-9]{8,17}$", var.vpc_id))
+    error_message = "VPC ID must be a valid AWS VPC identifier."
+  }
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for Fargate tasks"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.private_subnet_ids) >= 2
+    error_message = "At least 2 private subnets required for high availability."
+  }
+}
+
+variable "public_subnet_ids" {
+  description = "List of public subnet IDs for the ALB"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.public_subnet_ids) >= 2
+    error_message = "At least 2 public subnets required for ALB."
+  }
+}
+
+variable "container_image" {
+  description = "Docker image URI for the backend container"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Port the container listens on"
+  type        = number
+  default     = 8000
+
+  validation {
+    condition     = var.container_port > 0 && var.container_port <= 65535
+    error_message = "Container port must be between 1 and 65535."
+  }
+}
+
+variable "desired_count" {
+  description = "Desired number of Fargate tasks (G2)"
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.desired_count >= 1 && var.desired_count <= 10
+    error_message = "Desired count must be between 1 and 10."
+  }
+}
+
+variable "cpu" {
+  description = "CPU units for the Fargate task (256, 512, 1024, 2048, 4096)"
+  type        = number
+  default     = 256
+
+  validation {
+    condition     = contains([256, 512, 1024, 2048, 4096], var.cpu)
+    error_message = "CPU must be one of: 256, 512, 1024, 2048, 4096."
+  }
+}
+
+variable "memory" {
+  description = "Memory in MiB for the Fargate task"
+  type        = number
+  default     = 512
+
+  validation {
+    condition     = var.memory >= 512 && var.memory <= 30720
+    error_message = "Memory must be between 512 and 30720 MiB."
+  }
+}
+
+variable "health_check_path" {
+  description = "Health check endpoint path (G9)"
+  type        = string
+  default     = "/health"
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}
+```
+
+### infrastructure/modules/ecs/main.tf
+
+```hcl
+# @module taskflow_ecs
+# @description ECS Fargate service with ALB for TaskFlow application
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = merge(var.tags, {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Module      = "taskflow-ecs"
+  })
+}
+
+# ============================================================================
+# ECS Cluster (G1)
+# ============================================================================
+
+resource "aws_ecs_cluster" "main" {
+  name = "${local.name_prefix}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# CloudWatch Log Group (G5)
+# ============================================================================
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/${local.name_prefix}"
+  retention_in_days = 30
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# IAM Roles (G6)
+# ============================================================================
+
+data "aws_iam_policy_document" "ecs_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${local.name_prefix}-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task_role" {
+  name               = "${local.name_prefix}-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# Security Groups (G7)
+# ============================================================================
+
+resource "aws_security_group" "alb" {
+  name_prefix = "${local.name_prefix}-alb-"
+  vpc_id      = var.vpc_id
+  description = "Security group for TaskFlow ALB"
+
+  ingress {
+    description = "HTTPS from internet"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP redirect"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-alb-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "ecs_tasks" {
+  name_prefix = "${local.name_prefix}-ecs-"
+  vpc_id      = var.vpc_id
+  description = "Security group for TaskFlow ECS tasks"
+
+  ingress {
+    description     = "Allow traffic from ALB only"
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-ecs-sg"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ============================================================================
+# Application Load Balancer (G3)
+# ============================================================================
+
+resource "aws_lb" "main" {
+  name               = "${local.name_prefix}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+
+  tags = local.common_tags
+}
+
+resource "aws_lb_target_group" "main" {
+  name        = "${local.name_prefix}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    path                = var.health_check_path
+    port                = "traffic-port"
+    matcher             = "200"
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# ECS Task Definition (G4, G5, G8)
+# ============================================================================
+
+resource "aws_ecs_task_definition" "main" {
+  family                   = "${local.name_prefix}-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "taskflow-api"
+      image     = var.container_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      # G8: Run as non-root
+      user = "1000:1000"
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ecs.name
+          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:${var.container_port}${var.health_check_path} || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+
+      environment = [
+        {
+          name  = "ENVIRONMENT"
+          value = var.environment
+        }
+      ]
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+data "aws_region" "current" {}
+
+# ============================================================================
+# ECS Service (G2, G10)
+# ============================================================================
+
+resource "aws_ecs_service" "main" {
+  name            = "${local.name_prefix}-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.main.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.main.arn
+    container_name   = "taskflow-api"
+    container_port   = var.container_port
+  }
+
+  tags = local.common_tags
+
+  depends_on = [aws_lb_listener.http]
+}
+```
+
+### infrastructure/modules/ecs/outputs.tf
+
+```hcl
+# @module taskflow_ecs_outputs
+# @description Output values for the TaskFlow ECS module
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+output "cluster_arn" {
+  description = "ARN of the ECS cluster"
+  value       = aws_ecs_cluster.main.arn
+}
+
+output "cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "service_name" {
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.main.name
+}
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_zone_id" {
+  description = "Route53 zone ID of the ALB for DNS alias records"
+  value       = aws_lb.main.zone_id
+}
+
+output "target_group_arn" {
+  description = "ARN of the ALB target group"
+  value       = aws_lb_target_group.main.arn
+}
+
+output "task_execution_role_arn" {
+  description = "ARN of the ECS task execution IAM role"
+  value       = aws_iam_role.task_execution.arn
+}
+
+output "task_role_arn" {
+  description = "ARN of the ECS task IAM role"
+  value       = aws_iam_role.task_role.arn
+}
+
+output "ecs_security_group_id" {
+  description = "Security group ID for ECS tasks"
+  value       = aws_security_group.ecs_tasks.id
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group name for ECS tasks"
+  value       = aws_cloudwatch_log_group.ecs.name
+}
+```
+
+### infrastructure/environments/dev/main.tf
+
+```hcl
+# @module taskflow_dev
+# @description Development environment configuration for TaskFlow
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket         = "taskflow-terraform-state"
+    key            = "dev/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Project     = "taskflow"
+      Environment = "dev"
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# -- Data Sources --
+data "aws_vpc" "main" {
+  tags = { Name = "taskflow-dev-vpc" }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+  tags = { Tier = "private" }
+}
+
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+  tags = { Tier = "public" }
+}
+
+# -- ECS Module --
+module "ecs" {
+  source = "../../modules/ecs"
+
+  project_name       = "taskflow"
+  environment        = "dev"
+  vpc_id             = data.aws_vpc.main.id
+  private_subnet_ids = data.aws_subnets.private.ids
+  public_subnet_ids  = data.aws_subnets.public.ids
+  container_image    = "123456789012.dkr.ecr.us-east-1.amazonaws.com/taskflow:dev"
+  container_port     = 8000
+  desired_count      = 1
+  cpu                = 256
+  memory             = 512
+  health_check_path  = "/health"
+
+  tags = {
+    CostCenter = "engineering"
+  }
+}
+
+# -- Outputs --
+output "alb_dns_name" {
+  description = "ALB DNS name for the dev environment"
+  value       = module.ecs.alb_dns_name
+}
+
+output "cluster_name" {
+  description = "ECS cluster name"
+  value       = module.ecs.cluster_name
+}
+```
+
+### Checkpoint: Infrastructure validation
+
+```bash
+# Navigate to infrastructure directory
+cd infrastructure
+
+# Format all Terraform files
+terraform fmt -recursive
+
+# Initialize modules for validation
+cd modules/ecs && terraform init -backend=false
+terraform validate
+
+# Expected output:
+# Success! The configuration is valid.
+
+cd ../../environments/dev && terraform init -backend=false
+terraform validate
+
+# Verify CONTRACT.md exists
+cat modules/ecs/CONTRACT.md | head -5
+# Expected: "# Module Contract: taskflow-ecs"
+```
+
+---
+
+## Step 5: Docker Configuration (5 min)
+
+### backend/Dockerfile
+
+```dockerfile
+# @module taskflow_backend_dockerfile
+# @description Multi-stage Docker build for FastAPI backend
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+# ============================================================================
+# Stage 1: Build dependencies
+# ============================================================================
+FROM python:3.11-slim AS builder
+
+WORKDIR /build
+
+# Install uv for fast dependency resolution
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copy dependency files first for layer caching
+COPY pyproject.toml ./
+
+# Install production dependencies only
+RUN uv sync --no-dev --frozen
+
+# ============================================================================
+# Stage 2: Production image
+# ============================================================================
+FROM python:3.11-slim AS production
+
+# Security: Run as non-root user (G8)
+RUN groupadd --gid 1000 appuser && \
+    useradd --uid 1000 --gid 1000 --create-home appuser
+
+WORKDIR /app
+
+# Copy virtual environment from builder
+COPY --from=builder /build/.venv /app/.venv
+
+# Copy application source
+COPY src/ ./src/
+
+# Set environment variables
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Switch to non-root user
+USER appuser
+
+# Expose API port
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
+# Start the application
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+### frontend/Dockerfile
+
+```dockerfile
+# @module taskflow_frontend_dockerfile
+# @description Multi-stage Docker build for React frontend
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+# ============================================================================
+# Stage 1: Install dependencies
+# ============================================================================
+FROM node:20-alpine AS deps
+
+WORKDIR /app
+
+# Copy dependency manifests for layer caching
+COPY package.json package-lock.json ./
+
+# Install production + dev dependencies (needed for build)
+RUN npm ci
+
+# ============================================================================
+# Stage 2: Build application
+# ============================================================================
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependencies from previous stage
+COPY --from=deps /app/node_modules ./node_modules
+
+# Copy source files
+COPY . .
+
+# Build production bundle
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
+
+RUN npm run build
+
+# ============================================================================
+# Stage 3: Production image with nginx
+# ============================================================================
+FROM nginx:1.27-alpine AS production
+
+# Copy custom nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built assets from builder
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Security: Run as non-root
+RUN chown -R nginx:nginx /usr/share/nginx/html && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    touch /var/run/nginx.pid && \
+    chown -R nginx:nginx /var/run/nginx.pid
+
+USER nginx
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+### frontend/nginx.conf
+
+```text
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA routing: serve index.html for all non-file routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # API proxy to backend
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+}
+```
+
+### docker-compose.yml (root)
+
+```yaml
+# docker-compose.yml - Local development environment with hot reload
+#
+# @module taskflow_docker_compose
+# @description Docker Compose configuration for local development
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+services:
+  # -- Backend API --
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: production
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://taskflow:taskflow@db:5432/taskflow
+      - ENVIRONMENT=development
+    volumes:
+      - ./backend/src:/app/src:ro
+    command: >
+      uvicorn src.main:app
+      --host 0.0.0.0
+      --port 8000
+      --reload
+      --reload-dir /app/src
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # -- Frontend SPA --
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      target: deps
+    ports:
+      - "3000:3000"
+    environment:
+      - VITE_API_URL=http://localhost:8000/api/v1
+    volumes:
+      - ./frontend/src:/app/src:ro
+      - ./frontend/public:/app/public:ro
+    command: npx vite --host 0.0.0.0 --port 3000
+    depends_on:
+      - backend
+
+  # -- PostgreSQL Database --
+  db:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: taskflow
+      POSTGRES_PASSWORD: taskflow
+      POSTGRES_DB: taskflow
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U taskflow"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+    driver: local
+```
+
+### Checkpoint: Docker validation
+
+```bash
+# Build all images
+docker compose build
+
+# Start services
+docker compose up -d
+
+# Verify all containers are healthy
+docker compose ps
+
+# Expected output:
+# NAME                 STATUS
+# taskflow-backend-1   Up (healthy)
+# taskflow-frontend-1  Up
+# taskflow-db-1        Up (healthy)
+
+# Test backend health
+curl http://localhost:8000/health
+# Expected: {"status":"healthy","service":"taskflow-api","timestamp":"..."}
+
+# Test frontend
+curl -s http://localhost:3000 | head -5
+# Expected: HTML content with <div id="root">
+
+# Tear down
+docker compose down
+```
+
+---
+
+## Step 6: Monorepo CI/CD (8 min)
+
+### .github/workflows/ci.yml
+
+```yaml
+# .github/workflows/ci.yml - Monorepo CI pipeline with path-based triggers
+#
+# @module taskflow_ci
+# @description GitHub Actions CI pipeline for multi-language monorepo
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs for the same branch
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ========================================================================
+  # Detect changed paths
+  # ========================================================================
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      infrastructure: ${{ steps.filter.outputs.infrastructure }}
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'shared/**'
+            frontend:
+              - 'frontend/**'
+              - 'shared/**'
+            infrastructure:
+              - 'infrastructure/**'
+            docker:
+              - 'docker-compose.yml'
+              - 'backend/Dockerfile'
+              - 'frontend/Dockerfile'
+
+  # ========================================================================
+  # Pre-commit (runs on all changes)
+  # ========================================================================
+  pre-commit:
+    name: Pre-commit Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: pre-commit/action@v3.0.1
+
+  # ========================================================================
+  # Backend CI
+  # ========================================================================
+  backend:
+    name: Backend (Python)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint with black
+        run: uv run black --check src/ tests/
+
+      - name: Lint with flake8
+        run: uv run flake8 src/ tests/
+
+      - name: Type check with mypy
+        run: uv run mypy src/
+
+      - name: Run tests with coverage
+        run: uv run pytest tests/ -v --cov=src --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage.xml
+
+  # ========================================================================
+  # Frontend CI
+  # ========================================================================
+  frontend:
+    name: Frontend (TypeScript)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.frontend == 'true'
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Run tests
+        run: npm test -- --coverage
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/dist
+          retention-days: 7
+
+  # ========================================================================
+  # Infrastructure CI
+  # ========================================================================
+  infrastructure:
+    name: Infrastructure (Terraform)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.infrastructure == 'true'
+    defaults:
+      run:
+        working-directory: infrastructure
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.0"
+
+      - name: Terraform format check
+        run: terraform fmt -check -recursive
+
+      - name: Validate ECS module
+        run: |
+          cd modules/ecs
+          terraform init -backend=false
+          terraform validate
+
+      - name: Validate dev environment
+        run: |
+          cd environments/dev
+          terraform init -backend=false
+          terraform validate
+
+  # ========================================================================
+  # Docker Build Validation
+  # ========================================================================
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.docker == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build backend image
+        run: docker build -t taskflow-backend:test ./backend
+
+      - name: Build frontend image
+        run: docker build -t taskflow-frontend:test ./frontend
+
+      - name: Verify backend health
+        run: |
+          docker run -d --name backend-test -p 8000:8000 taskflow-backend:test
+          sleep 5
+          curl -f http://localhost:8000/health
+          docker stop backend-test
+
+  # ========================================================================
+  # CI Status Gate
+  # ========================================================================
+  ci-status:
+    name: CI Status
+    runs-on: ubuntu-latest
+    needs: [pre-commit, backend, frontend, infrastructure, docker]
+    if: always()
+    steps:
+      - name: Check job results
+        run: |
+          echo "Pre-commit: ${{ needs.pre-commit.result }}"
+          echo "Backend:    ${{ needs.backend.result }}"
+          echo "Frontend:   ${{ needs.frontend.result }}"
+          echo "Infra:      ${{ needs.infrastructure.result }}"
+          echo "Docker:     ${{ needs.docker.result }}"
+
+          # Fail if any required job failed (skipped is ok)
+          if [[ "${{ needs.pre-commit.result }}" == "failure" ]]; then
+            echo "::error::Pre-commit checks failed"
+            exit 1
+          fi
+          if [[ "${{ needs.backend.result }}" == "failure" ]]; then
+            echo "::error::Backend CI failed"
+            exit 1
+          fi
+          if [[ "${{ needs.frontend.result }}" == "failure" ]]; then
+            echo "::error::Frontend CI failed"
+            exit 1
+          fi
+          if [[ "${{ needs.infrastructure.result }}" == "failure" ]]; then
+            echo "::error::Infrastructure CI failed"
+            exit 1
+          fi
+          if [[ "${{ needs.docker.result }}" == "failure" ]]; then
+            echo "::error::Docker build failed"
+            exit 1
+          fi
+
+          echo "All CI checks passed!"
+```
+
+### .github/workflows/deploy.yml
+
+```yaml
+# .github/workflows/deploy.yml - Deployment pipeline for staging and production
+#
+# @module taskflow_deploy
+# @description Deployment workflow triggered after CI passes on main
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  deploy-staging:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push backend image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/taskflow-backend:$IMAGE_TAG ./backend
+          docker push $ECR_REGISTRY/taskflow-backend:$IMAGE_TAG
+
+      - name: Build and push frontend image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build \
+            --build-arg VITE_API_URL=https://api.staging.taskflow.example.com/api/v1 \
+            -t $ECR_REGISTRY/taskflow-frontend:$IMAGE_TAG \
+            ./frontend
+          docker push $ECR_REGISTRY/taskflow-frontend:$IMAGE_TAG
+
+      - name: Deploy to ECS
+        run: |
+          aws ecs update-service \
+            --cluster taskflow-staging-cluster \
+            --service taskflow-staging-service \
+            --force-new-deployment \
+            --region us-east-1
+```
+
+### Checkpoint: CI/CD validation
+
+```bash
+# Validate workflow syntax
+# Install actionlint: https://github.com/rhysd/actionlint
+actionlint .github/workflows/ci.yml
+actionlint .github/workflows/deploy.yml
+
+# Verify YAML syntax
+yamllint .github/workflows/ci.yml
+yamllint .github/workflows/deploy.yml
+
+# Expected: No errors
+```
+
+---
+
+## Step 7: Cross-Language Validation (2 min)
+
+### Shared JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TaskFlow Task",
+  "description": "Shared schema for task validation across backend and frontend",
+  "type": "object",
+  "required": ["title"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique task identifier"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Task title"
+    },
+    "description": {
+      "type": ["string", "null"],
+      "maxLength": 2000,
+      "description": "Task description"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["todo", "in_progress", "done", "archived"],
+      "default": "todo"
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"],
+      "default": "medium"
+    },
+    "assignee": {
+      "type": ["string", "null"],
+      "maxLength": 100
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}
+```
+
+The shared schema in `shared/schemas/task.schema.json` ensures that both the Python backend (Pydantic models) and the TypeScript frontend (type definitions) stay in sync.
+
+### Root validation script
+
+```bash
+#!/usr/bin/env bash
+# scripts/validate-all.sh - Cross-language validation orchestrator
+#
+# @module validate_all
+# @description Runs validation for all monorepo components
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-01-15
+# @status stable
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+FAILED=0
+
+log_pass() { echo -e "${GREEN}PASS${NC}: $1"; }
+log_fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=1; }
+log_info() { echo -e "${YELLOW}INFO${NC}: $1"; }
+
+echo "============================================="
+echo "TaskFlow Monorepo Validation"
+echo "============================================="
+echo ""
+
+# -- Backend --
+log_info "Validating Python backend..."
+cd "$ROOT_DIR/backend"
+if uv run black --check src/ tests/ 2>/dev/null; then
+    log_pass "Backend formatting (black)"
+else
+    log_fail "Backend formatting (black)"
+fi
+
+if uv run flake8 src/ tests/ 2>/dev/null; then
+    log_pass "Backend linting (flake8)"
+else
+    log_fail "Backend linting (flake8)"
+fi
+
+if uv run pytest tests/ -q 2>/dev/null; then
+    log_pass "Backend tests (pytest)"
+else
+    log_fail "Backend tests (pytest)"
+fi
+
+# -- Frontend --
+log_info "Validating TypeScript frontend..."
+cd "$ROOT_DIR/frontend"
+if npx tsc --noEmit 2>/dev/null; then
+    log_pass "Frontend type checking (tsc)"
+else
+    log_fail "Frontend type checking (tsc)"
+fi
+
+if npm run lint 2>/dev/null; then
+    log_pass "Frontend linting (eslint)"
+else
+    log_fail "Frontend linting (eslint)"
+fi
+
+if npm test 2>/dev/null; then
+    log_pass "Frontend tests (vitest)"
+else
+    log_fail "Frontend tests (vitest)"
+fi
+
+# -- Infrastructure --
+log_info "Validating Terraform infrastructure..."
+cd "$ROOT_DIR/infrastructure"
+if terraform fmt -check -recursive 2>/dev/null; then
+    log_pass "Terraform formatting (fmt)"
+else
+    log_fail "Terraform formatting (fmt)"
+fi
+
+# -- Pre-commit --
+log_info "Running pre-commit hooks..."
+cd "$ROOT_DIR"
+if pre-commit run --all-files 2>/dev/null; then
+    log_pass "Pre-commit hooks"
+else
+    log_fail "Pre-commit hooks"
+fi
+
+echo ""
+echo "============================================="
+if [ "$FAILED" -eq 0 ]; then
+    echo -e "${GREEN}All validations passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some validations failed.${NC}"
+    exit 1
+fi
+```
+
+### Run full validation
+
+```bash
+# Using Make
+make validate
+
+# Or using the validation script directly
+bash scripts/validate-all.sh
+
+# Expected output:
+# =============================================
+# TaskFlow Monorepo Validation
+# =============================================
+#
+# INFO: Validating Python backend...
+# PASS: Backend formatting (black)
+# PASS: Backend linting (flake8)
+# PASS: Backend tests (pytest)
+# INFO: Validating TypeScript frontend...
+# PASS: Frontend type checking (tsc)
+# PASS: Frontend linting (eslint)
+# PASS: Frontend tests (vitest)
+# INFO: Validating Terraform infrastructure...
+# PASS: Terraform formatting (fmt)
+# INFO: Running pre-commit hooks...
+# PASS: Pre-commit hooks
+#
+# =============================================
+# All validations passed!
+```
+
+---
+
+## Checkpoint: Final Verification
+
+Run through this checklist to confirm everything is correctly set up.
+
+```text
+Final Verification Checklist
+=============================
+[ ] Root .editorconfig exists with language-specific settings
+[ ] Root .pre-commit-config.yaml covers Python, TypeScript, Terraform, Shell, YAML, Markdown
+[ ] Root Makefile has targets: setup, dev, test, lint, format, validate, clean
+[ ] Root docker-compose.yml starts backend, frontend, and database
+
+Backend (Python):
+[ ] pyproject.toml has project metadata, dependencies, and tool config
+[ ] src/main.py has FastAPI app with /health and /ready endpoints
+[ ] src/models/task.py has Pydantic models with field validation
+[ ] src/routes/tasks.py has full CRUD (POST, GET, PATCH, DELETE)
+[ ] All .py files have @module metadata tags
+[ ] Tests pass: uv run pytest tests/ -v
+[ ] Linting passes: uv run black --check src/ tests/ && uv run flake8 src/ tests/
+
+Frontend (TypeScript):
+[ ] tsconfig.json has strict: true
+[ ] package.json has lint, format, format:check, test, build scripts
+[ ] src/types/task.ts has typed interfaces matching backend models
+[ ] src/services/api.ts has typed API client with error handling
+[ ] src/hooks/useTasks.ts has custom hook with CRUD operations
+[ ] src/components/TaskList.tsx and TaskForm.tsx are fully typed
+[ ] src/App.tsx composes all components
+[ ] All .ts/.tsx files have @module JSDoc metadata
+
+Infrastructure (Terraform):
+[ ] modules/ecs/CONTRACT.md has numbered guarantees (G1-G10)
+[ ] modules/ecs/variables.tf has validation blocks on all inputs
+[ ] modules/ecs/main.tf references guarantee numbers in comments
+[ ] modules/ecs/outputs.tf exports all required values
+[ ] environments/dev/main.tf uses the ECS module
+[ ] terraform fmt -check -recursive passes
+[ ] terraform validate passes for all modules
+
+Docker:
+[ ] backend/Dockerfile is multi-stage with non-root user
+[ ] frontend/Dockerfile is multi-stage with nginx serving
+[ ] docker-compose.yml has health checks on backend and database
+[ ] docker compose build succeeds
+
+CI/CD:
+[ ] .github/workflows/ci.yml uses path-based triggers
+[ ] CI runs backend/frontend/infra jobs in parallel
+[ ] CI has a status gate job that aggregates results
+[ ] .github/workflows/deploy.yml triggers after CI passes
+```
+
+```bash
+# Quick automated check
+echo "--- Checking file existence ---"
+for f in \
+  .editorconfig \
+  .pre-commit-config.yaml \
+  Makefile \
+  docker-compose.yml \
+  backend/pyproject.toml \
+  backend/src/main.py \
+  backend/src/models/task.py \
+  backend/src/routes/tasks.py \
+  backend/tests/test_tasks.py \
+  frontend/package.json \
+  frontend/tsconfig.json \
+  frontend/src/App.tsx \
+  frontend/src/types/task.ts \
+  frontend/src/services/api.ts \
+  infrastructure/modules/ecs/CONTRACT.md \
+  infrastructure/modules/ecs/main.tf \
+  infrastructure/modules/ecs/variables.tf \
+  infrastructure/modules/ecs/outputs.tf \
+  infrastructure/environments/dev/main.tf \
+  .github/workflows/ci.yml \
+  .github/workflows/deploy.yml; do
+  if [ -f "$f" ]; then
+    echo "  FOUND: $f"
+  else
+    echo "  MISSING: $f"
+  fi
+done
+```
+
+---
+
+## Common Troubleshooting
+
+### Problem: Pre-commit hooks fail on TypeScript files
+
+```text
+Symptom: ESLint errors about missing parser or plugin
+```
+
+```bash
+# Solution: Install ESLint dependencies in the frontend directory
+cd frontend && npm install
+
+# Then retry pre-commit
+pre-commit run --all-files
+```
+
+### Problem: Docker Compose backend fails to connect to database
+
+```text
+Symptom: asyncpg.exceptions.ConnectionDoesNotExistError
+```
+
+```bash
+# Solution: Ensure the database is healthy before starting the backend
+docker compose up db -d
+docker compose exec db pg_isready -U taskflow
+
+# Once healthy, start the backend
+docker compose up backend -d
+```
+
+### Problem: Terraform validate fails with provider errors
+
+```text
+Symptom: "Failed to query available provider packages"
+```
+
+```bash
+# Solution: Initialize with -backend=false for local validation
+cd infrastructure/modules/ecs
+terraform init -backend=false
+terraform validate
+```
+
+### Problem: Frontend build fails with type errors after backend model changes
+
+```text
+Symptom: TypeScript errors in api.ts or types/task.ts
+```
+
+```bash
+# Solution: Regenerate types from the shared schema
+# Compare shared/schemas/task.schema.json with frontend types
+diff <(jq '.properties | keys' shared/schemas/task.schema.json) \
+     <(grep -oP 'readonly \K\w+|^\s+\K\w+(?=[\?:])'  frontend/src/types/task.ts | sort -u)
+
+# Update frontend/src/types/task.ts to match any new fields
+```
+
+### Problem: CI workflow skips all jobs
+
+```text
+Symptom: All backend/frontend/infra jobs show as "skipped"
+```
+
+```yaml
+# Cause: The paths-filter detects no changes in the relevant directories.
+# This is expected behavior when changes only affect files outside
+# backend/, frontend/, and infrastructure/.
+#
+# The pre-commit job always runs regardless of path changes.
+# The ci-status gate treats "skipped" as passing.
+```
+
+### Problem: Makefile targets fail with "command not found"
+
+```text
+Symptom: make: uv: command not found
+```
+
+```bash
+# Solution: Ensure uv is installed and in PATH
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+# Add to your shell profile
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+
+# Verify
+uv --version
+make setup-backend
+```
+
+### Problem: Port conflicts when running locally
+
+```text
+Symptom: "address already in use" errors on ports 8000, 3000, or 5432
+```
+
+```bash
+# Find and kill processes using the ports
+lsof -i :8000 -i :3000 -i :5432
+
+# Or use different ports in docker-compose override
+# Create docker-compose.override.yml:
+cat > docker-compose.override.yml << 'OVERRIDE'
+services:
+  backend:
+    ports:
+      - "8001:8000"
+  frontend:
+    ports:
+      - "3001:3000"
+  db:
+    ports:
+      - "5433:5432"
+OVERRIDE
+```
+
+---
+
+## Next Steps
+
+After completing this tutorial, consider these follow-up activities.
+
+```text
+Recommended Next Steps
+======================
+1. Add database migrations with Alembic (backend/alembic/)
+2. Add end-to-end tests with Playwright (e2e/)
+3. Add Terraform modules for RDS and networking
+4. Set up staging environment in infrastructure/environments/staging/
+5. Add monitoring with CloudWatch dashboards
+6. Implement JWT authentication in the backend
+7. Add the Dukes metadata validation script to the CI pipeline
+```
+
+### Related Style Guide References
+
+```text
+Reference                                    Section
+-----------------------------------------------------
+Python conventions                           02_language_guides/python
+TypeScript conventions                       02_language_guides/typescript
+Terraform conventions                        02_language_guides/terraform
+Docker conventions                           02_language_guides/docker
+GitHub Actions conventions                   02_language_guides/github_actions
+Makefile conventions                         02_language_guides/makefile
+CONTRACT.md template                         04_templates/contract_template
+IaC testing standards                        05_ci_cd/iac_testing
+```

--- a/docs/12_tutorials/index.md
+++ b/docs/12_tutorials/index.md
@@ -1,0 +1,154 @@
+---
+title: "Tutorial Series"
+description: "Step-by-step tutorials covering common real-world scenarios with the Dukes Engineering Style Guide"
+author: "Tyler Dukes"
+tags: [tutorials, getting-started, walkthrough, hands-on, learning]
+category: "Tutorials"
+status: "active"
+---
+
+<!-- markdownlint-disable MD013 -->
+
+## Overview
+
+This tutorial series provides hands-on, step-by-step walkthroughs for the most common real-world
+scenarios you will encounter when adopting the Dukes Engineering Style Guide. Each tutorial builds a
+complete, working example from scratch.
+
+---
+
+## Tutorial Map
+
+```mermaid
+graph TD
+    Start[New to Style Guide?] --> T4[Tutorial 4: Team Onboarding<br/>20 min]
+    T4 --> T1[Tutorial 1: Python Project<br/>30 min]
+    T4 --> T2[Tutorial 2: Terraform Module<br/>45 min]
+    T1 --> T3[Tutorial 3: Full-Stack App<br/>60 min]
+    T2 --> T3
+    T4 --> T5[Tutorial 5: Manual to Automated<br/>40 min]
+    T5 --> T3
+
+    style T4 fill:#e3f2fd
+    style T1 fill:#e8f5e9
+    style T2 fill:#fff3e0
+    style T3 fill:#f3e5f5
+    style T5 fill:#fce4ec
+```
+
+---
+
+## Tutorials
+
+| # | Tutorial | Time | Difficulty | Languages |
+|---|----------|------|------------|-----------|
+| 1 | [Zero to Validated Python Project](python_project.md) | 30 min | Beginner | Python, YAML |
+| 2 | [Migrating Existing Terraform Module](terraform_migration.md) | 45 min | Intermediate | Terraform, HCL, Go |
+| 3 | [Full-Stack App with Multiple Languages](fullstack_app.md) | 60 min | Advanced | Python, TypeScript, Terraform |
+| 4 | [Team Onboarding](team_onboarding.md) | 20 min | Beginner | All |
+| 5 | [From Manual to Automated](manual_to_automated.md) | 40 min | Intermediate | Bash, YAML, Python |
+
+---
+
+## Prerequisites
+
+All tutorials assume the following baseline tools are installed:
+
+```bash
+# Verify prerequisites
+python3 --version   # Python 3.10+
+git --version       # Git 2.30+
+docker --version    # Docker 20.10+
+code --version      # VS Code (recommended)
+```
+
+```bash
+# Install uv (Python package manager)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install pre-commit
+pip install pre-commit
+
+# Install terraform (for tutorials 2 and 3)
+# macOS
+brew install terraform
+
+# Linux
+sudo apt-get install -y terraform
+```
+
+Additional prerequisites are listed at the start of each tutorial.
+
+---
+
+## How to Use These Tutorials
+
+Each tutorial follows a consistent format:
+
+```text
+Tutorial Structure
+==================
+1. Prerequisites          - Tools and knowledge required
+2. What You Will Build    - End-state description
+3. Step-by-Step Guide     - Numbered, sequential instructions
+4. Checkpoints            - Verification steps after each section
+5. Common Troubleshooting - Solutions for frequent issues
+6. Next Steps             - Where to go after completing
+```
+
+**Checkpoints** appear throughout each tutorial as verification steps:
+
+```bash
+# Example checkpoint - verify your project structure
+ls -la
+# Expected output:
+# .pre-commit-config.yaml
+# pyproject.toml
+# src/
+# tests/
+```
+
+**Troubleshooting** sections address the most common issues:
+
+```text
+Problem: pre-commit hooks fail on first run
+Solution: Run `pre-commit install --install-hooks` to download hook environments
+```
+
+---
+
+## Recommended Learning Paths
+
+### Path 1: Python Developer
+
+```text
+Tutorial 4 (Team Onboarding)
+    └── Tutorial 1 (Python Project)
+        └── Tutorial 5 (Manual to Automated)
+            └── Tutorial 3 (Full-Stack App)
+```
+
+### Path 2: Infrastructure Engineer
+
+```text
+Tutorial 4 (Team Onboarding)
+    └── Tutorial 2 (Terraform Module)
+        └── Tutorial 5 (Manual to Automated)
+            └── Tutorial 3 (Full-Stack App)
+```
+
+### Path 3: Team Lead / Manager
+
+```text
+Tutorial 4 (Team Onboarding)
+    └── Tutorial 5 (Manual to Automated)
+```
+
+### Path 4: Full-Stack Developer
+
+```text
+Tutorial 4 (Team Onboarding)
+    └── Tutorial 1 (Python Project)
+        └── Tutorial 2 (Terraform Module)
+            └── Tutorial 3 (Full-Stack App)
+```

--- a/docs/12_tutorials/manual_to_automated.md
+++ b/docs/12_tutorials/manual_to_automated.md
@@ -1,0 +1,2115 @@
+---
+title: "Tutorial 5: From Manual to Automated"
+description: "Take a project from zero automation to fully automated validation in 40 minutes"
+author: "Tyler Dukes"
+tags: [tutorials, automation, ci-cd, pre-commit, github-actions, quality-gates, linting]
+category: "Tutorials"
+status: "active"
+---
+
+<!-- markdownlint-disable MD013 -->
+
+## Overview
+
+This tutorial walks you through building a progressive automation pipeline, starting from manual
+checks and ending with a fully automated CI/CD validation system. Each step builds on the previous,
+so you can adopt automation at whatever pace fits your team.
+
+### What You Will Build
+
+```text
+Automation Pipeline Progression
+================================
+
+Level 0: Manual           - Run checks by hand, hope for the best
+Level 1: EditorConfig     - Consistent formatting across all editors
+Level 2: Pre-commit Hooks - Automated local checks before every commit
+Level 3: CI/CD Pipeline   - Server-side validation on every push
+Level 4: Auto-fixes       - Tools fix problems automatically
+Level 5: Quality Gates    - Spell checking, link checking, metrics
+Level 6: Monitoring       - Track trends and measure improvement
+```
+
+### Time Estimate
+
+```text
+Step 1: Manual Validation Baseline ............  5 min
+Step 2: Add EditorConfig ......................  3 min
+Step 3: Add Pre-commit Hooks ..................  8 min
+Step 4: Add CI/CD Pipeline .................... 10 min
+Step 5: Enable Auto-fixes .....................  5 min
+Step 6: Add Quality Gates .....................  5 min
+Step 7: Monitor and Measure ...................  4 min
+                                               ------
+Total ......................................... 40 min
+```
+
+### Prerequisites
+
+```bash
+# Verify required tools
+python3 --version   # Python 3.10+
+git --version       # Git 2.30+
+```
+
+```bash
+# Install uv (Python package manager)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install pre-commit
+pip install pre-commit
+
+# Install Node.js tooling (for spell checking and markdown linting)
+npm install -g cspell markdownlint-cli
+```
+
+```bash
+# Create a sample project to work with
+mkdir -p ~/automation-tutorial/src ~/automation-tutorial/tests
+cd ~/automation-tutorial
+git init
+```
+
+```bash
+# Create a sample Python file with intentional issues
+cat > src/app.py << 'PYEOF'
+import os
+import sys
+import json
+
+def get_config(path):
+    with open(path) as f:
+        data=json.load(f)
+    return data
+
+def process_items(items):
+    result = []
+    for item in items:
+        if item["status"]=="active":
+            result.append(item["name"])
+    return result
+
+class  DataProcessor:
+    def __init__(self,name):
+        self.name=name
+        self.items=[]
+
+    def add_item(self,item):
+        self.items.append(item)
+
+    def run(self):
+        return process_items(self.items)
+PYEOF
+```
+
+```bash
+# Create a sample Bash script with issues
+cat > src/deploy.sh << 'SHEOF'
+#!/bin/bash
+echo "Deploying application..."
+if [ $1 == "production" ]; then
+    echo "Deploying to production"
+    rm -rf /tmp/deploy/*
+fi
+echo "Done"
+SHEOF
+chmod +x src/deploy.sh
+```
+
+```bash
+# Create a sample Terraform file
+cat > src/main.tf << 'TFEOF'
+resource "aws_instance" "web" {
+ami           = "ami-0c55b159cbfafe1f0"
+instance_type = "t2.micro"
+tags = {
+Name = "web-server"
+Environment = "production"
+}
+}
+TFEOF
+```
+
+```bash
+# Create a YAML config with issues
+cat > src/config.yaml << 'YAMLEOF'
+app:
+  name: my-application
+  version: 1.0.0
+  database:
+    host: localhost
+    port: 5432
+    password: supersecretpassword123
+  features:
+    - name: feature-a
+      enabled: true
+    - name: feature-b
+      enabled: false
+YAMLEOF
+```
+
+---
+
+## Step 1: Manual Validation Baseline (5 min)
+
+Before automating anything, understand what manual validation looks like. This is the starting
+point most teams live with -- running checks by hand when they remember to.
+
+### The Manual Checklist
+
+```bash
+# Manual check 1: Python formatting
+echo "=== Checking Python formatting ==="
+python3 -m py_compile src/app.py && echo "Syntax OK" || echo "Syntax ERROR"
+```
+
+```bash
+# Manual check 2: Shell script issues
+echo "=== Checking shell scripts ==="
+bash -n src/deploy.sh && echo "Syntax OK" || echo "Syntax ERROR"
+```
+
+```bash
+# Manual check 3: YAML validity
+echo "=== Checking YAML files ==="
+python3 -c "import yaml; yaml.safe_load(open('src/config.yaml'))" && echo "Valid" || echo "Invalid"
+```
+
+```bash
+# Manual check 4: Look for secrets
+echo "=== Checking for potential secrets ==="
+grep -rn "password\|secret\|api_key\|token" src/ || echo "No secrets found"
+```
+
+### Automate the Manual Checks into a Script
+
+```bash
+cat > scripts/manual_checks.sh << 'EOF'
+#!/bin/bash
+# manual_checks.sh - Manual validation checklist
+# Run this before every commit (if you remember)
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+WARN=0
+
+check_pass() { echo "  PASS: $1"; ((PASS++)); }
+check_fail() { echo "  FAIL: $1"; ((FAIL++)); }
+check_warn() { echo "  WARN: $1"; ((WARN++)); }
+
+echo "============================================"
+echo "  Manual Validation Checklist"
+echo "============================================"
+echo ""
+
+# 1. Python syntax check
+echo "[1/6] Python Syntax"
+for f in $(find . -name "*.py" -not -path "./.venv/*"); do
+    if python3 -m py_compile "$f" 2>/dev/null; then
+        check_pass "$f"
+    else
+        check_fail "$f"
+    fi
+done
+echo ""
+
+# 2. Shell script syntax
+echo "[2/6] Shell Script Syntax"
+for f in $(find . -name "*.sh" -not -path "./.venv/*"); do
+    if bash -n "$f" 2>/dev/null; then
+        check_pass "$f"
+    else
+        check_fail "$f"
+    fi
+done
+echo ""
+
+# 3. YAML validity
+echo "[3/6] YAML Validity"
+for f in $(find . -name "*.yaml" -o -name "*.yml" | grep -v ".venv"); do
+    if python3 -c "import yaml; yaml.safe_load(open('$f'))" 2>/dev/null; then
+        check_pass "$f"
+    else
+        check_fail "$f"
+    fi
+done
+echo ""
+
+# 4. JSON validity
+echo "[4/6] JSON Validity"
+for f in $(find . -name "*.json" -not -path "./.venv/*" -not -path "./node_modules/*"); do
+    if python3 -c "import json; json.load(open('$f'))" 2>/dev/null; then
+        check_pass "$f"
+    else
+        check_fail "$f"
+    fi
+done
+echo ""
+
+# 5. Secret detection
+echo "[5/6] Secret Detection"
+SECRETS_FOUND=$(grep -rn \
+    --include="*.py" --include="*.sh" --include="*.yaml" --include="*.yml" \
+    --include="*.json" --include="*.tf" \
+    -E "(password|secret|api_key|token)\s*[:=]" . \
+    --exclude-dir=".venv" --exclude-dir="node_modules" 2>/dev/null || true)
+if [ -n "$SECRETS_FOUND" ]; then
+    echo "$SECRETS_FOUND" | while read -r line; do
+        check_warn "Potential secret: $line"
+    done
+else
+    check_pass "No hardcoded secrets detected"
+fi
+echo ""
+
+# 6. Trailing whitespace
+echo "[6/6] Trailing Whitespace"
+TRAILING=$(grep -rn ' $' \
+    --include="*.py" --include="*.sh" --include="*.yaml" --include="*.yml" \
+    --include="*.tf" --include="*.md" \
+    . --exclude-dir=".venv" --exclude-dir="node_modules" 2>/dev/null || true)
+if [ -n "$TRAILING" ]; then
+    echo "$TRAILING" | head -5 | while read -r line; do
+        check_warn "Trailing whitespace: $line"
+    done
+else
+    check_pass "No trailing whitespace found"
+fi
+echo ""
+
+# Summary
+echo "============================================"
+echo "  Results: $PASS passed, $FAIL failed, $WARN warnings"
+echo "============================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "STATUS: FAILED"
+    exit 1
+else
+    echo "STATUS: PASSED (with $WARN warnings)"
+    exit 0
+fi
+EOF
+chmod +x scripts/manual_checks.sh
+```
+
+```bash
+# Run the manual checks
+bash scripts/manual_checks.sh
+```
+
+```text
+# Expected output:
+============================================
+  Manual Validation Checklist
+============================================
+
+[1/6] Python Syntax
+  PASS: ./src/app.py
+
+[2/6] Shell Script Syntax
+  PASS: ./src/deploy.sh
+
+[3/6] YAML Validity
+  PASS: ./src/config.yaml
+
+[4/6] JSON Validity
+
+[5/6] Secret Detection
+  WARN: Potential secret: ./src/config.yaml:7:    password: supersecretpassword123
+
+[6/6] Trailing Whitespace
+  PASS: No trailing whitespace found
+
+============================================
+  Results: 4 passed, 0 failed, 1 warnings
+============================================
+STATUS: PASSED (with 1 warnings)
+```
+
+### The Problem with Manual Checks
+
+```text
+Why manual validation fails in practice:
+
+1. Inconsistency  - Different team members run different checks
+2. Forgetfulness   - People skip checks under deadline pressure
+3. Incomplete      - Manual scripts miss edge cases
+4. Slow feedback   - Issues found in review, not at commit time
+5. No enforcement  - Nothing prevents bad code from merging
+```
+
+### Checkpoint: Manual Baseline
+
+```bash
+# Verify you have the manual checks script
+ls -la scripts/manual_checks.sh
+# Expected: -rwxr-xr-x ... scripts/manual_checks.sh
+
+# Verify it runs
+bash scripts/manual_checks.sh && echo "Manual checks configured"
+```
+
+---
+
+## Step 2: Add EditorConfig (3 min)
+
+EditorConfig enforces consistent formatting across all editors and IDEs without any plugins
+for most editors. This is the lowest-friction automation you can add.
+
+### Create the EditorConfig File
+
+```bash
+cat > .editorconfig << 'EOF'
+# EditorConfig: https://EditorConfig.org
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Python files
+[*.py]
+indent_size = 4
+max_line_length = 100
+
+# YAML files
+[*.{yaml,yml}]
+indent_size = 2
+max_line_length = 120
+
+# Terraform and HCL files
+[*.{tf,tfvars,hcl}]
+indent_size = 2
+max_line_length = 120
+
+# Shell scripts
+[*.{sh,bash}]
+indent_size = 2
+max_line_length = 100
+
+# PowerShell scripts
+[*.{ps1,psm1,psd1}]
+indent_size = 4
+max_line_length = 100
+
+# TypeScript and JavaScript
+[*.{ts,tsx,js,jsx}]
+indent_size = 2
+max_line_length = 100
+
+# JSON files
+[*.{json,jsonc}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size = 2
+max_line_length = 120
+trim_trailing_whitespace = false
+
+# Dockerfiles
+[Dockerfile*]
+indent_size = 2
+
+# Makefiles (must use tabs)
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[{Makefile.*,*.mk}]
+indent_style = tab
+indent_size = 4
+
+# SQL files
+[*.sql]
+indent_size = 2
+max_line_length = 100
+
+# GitHub Actions
+[.github/workflows/*.{yml,yaml}]
+indent_size = 2
+
+# Groovy / Jenkinsfiles
+[*.groovy]
+indent_size = 2
+max_line_length = 120
+
+[Jenkinsfile*]
+indent_size = 2
+max_line_length = 120
+EOF
+```
+
+### Verify EditorConfig Works
+
+```bash
+# Install the editorconfig CLI checker
+pip install editorconfig-checker
+
+# Run it against your project
+editorconfig-checker src/
+```
+
+```text
+# Expected output (showing formatting issues EditorConfig catches):
+src/app.py:8: Wrong amount of trailing whitespace characters
+src/main.tf:3: Wrong indent style found (tabs instead of spaces)
+```
+
+```bash
+# Verify the file is in place
+cat .editorconfig | head -20
+```
+
+```text
+# Expected output:
+# EditorConfig: https://EditorConfig.org
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Python files
+[*.py]
+indent_size = 4
+max_line_length = 100
+```
+
+### What EditorConfig Catches Automatically
+
+```text
+Before EditorConfig:
+  - Tab vs spaces arguments on every PR
+  - Inconsistent line endings (CRLF vs LF)
+  - Missing final newlines
+  - Random trailing whitespace
+  - Python files with 2-space indent
+  - YAML files with 4-space indent
+
+After EditorConfig:
+  - All editors use the same settings
+  - Zero configuration for new team members
+  - Formatting issues caught at edit time
+  - Works with VS Code, IntelliJ, Vim, Emacs, and 20+ others
+```
+
+### Checkpoint: EditorConfig
+
+```bash
+# Verify EditorConfig exists and has correct structure
+grep -c '^\[' .editorconfig
+# Expected: 14 (or more section headers)
+
+# Verify root = true is set
+head -3 .editorconfig | grep "root = true"
+# Expected: root = true
+```
+
+---
+
+## Step 3: Add Pre-commit Hooks (8 min)
+
+Pre-commit hooks run automatically before every `git commit`, catching issues at the earliest
+possible point. We build the configuration progressively in three stages.
+
+### Stage 1: Basic File Checks
+
+```yaml
+# .pre-commit-config.yaml - Stage 1: Basic checks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ['--unsafe']
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+      - id: detect-private-key
+```
+
+```bash
+# Install pre-commit hooks
+pre-commit install
+
+# Run against all files to see current state
+pre-commit run --all-files
+```
+
+```text
+# Expected output:
+Trim Trailing Whitespace.............................Passed
+Fix End of Files.....................................Fixed
+Check Yaml...........................................Passed
+Check JSON...........................................(no files to check)Skipped
+Check for added large files..........................Passed
+Check for merge conflicts............................Passed
+Check for case conflicts.............................Passed
+Mixed line ending....................................Passed
+Detect Private Key...................................Passed
+```
+
+### Stage 2: Add Language Linters
+
+```yaml
+# .pre-commit-config.yaml - Stage 2: Add language-specific linters
+repos:
+  # General file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ['--unsafe']
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+      - id: detect-private-key
+
+  # Python formatting
+  - repo: https://github.com/psf/black
+    rev: 26.1.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  # Python linting
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: ['--max-line-length=100', '--extend-ignore=E203,W503']
+
+  # YAML linting
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: ['-d', '{extends: default, rules: {line-length: {max: 120}, document-start: disable}}']
+
+  # Shell script linting
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  # Markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: ['--fix']
+```
+
+```bash
+# Update hooks to install new environments
+pre-commit install --install-hooks
+
+# Run all hooks
+pre-commit run --all-files
+```
+
+```text
+# Expected output:
+Trim Trailing Whitespace.............................Passed
+Fix End of Files.....................................Passed
+Check Yaml...........................................Passed
+Check JSON...........................................(no files to check)Skipped
+Check for added large files..........................Passed
+Check for merge conflicts............................Passed
+Check for case conflicts.............................Passed
+Mixed line ending....................................Passed
+Detect Private Key...................................Passed
+black................................................Failed
+- hook id: black
+- files were modified by this hook
+
+reformatted src/app.py
+
+All done!
+1 file reformatted.
+
+flake8...............................................Passed
+yamllint.............................................Passed
+shellcheck...........................................Failed
+- hook id: shellcheck
+- exit code: 1
+
+In src/deploy.sh line 3:
+if [ $1 == "production" ]; then
+     ^-- SC2086: Double quote to prevent globbing and word splitting.
+        ^-- SC2039: In POSIX sh, == in place of = is undefined.
+```
+
+### Stage 3: Add Security Scanning
+
+```yaml
+# .pre-commit-config.yaml - Stage 3: Full configuration with security
+repos:
+  # General file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ['--unsafe']
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+      - id: detect-private-key
+
+  # Python formatting
+  - repo: https://github.com/psf/black
+    rev: 26.1.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  # Python linting
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: ['--max-line-length=100', '--extend-ignore=E203,W503']
+
+  # YAML linting
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: ['-d', '{extends: default, rules: {line-length: {max: 120}, document-start: disable}}']
+
+  # Shell script linting
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  # Markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: ['--fix']
+
+  # Terraform formatting
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+        args:
+          - '--args=--config=.terraform-docs.yml'
+
+  # Security: detect secrets in code
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+
+  # Security: check for common vulnerabilities
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.3
+    hooks:
+      - id: bandit
+        args: ['-c', 'pyproject.toml']
+        additional_dependencies: ['bandit[toml]']
+```
+
+```bash
+# Generate initial secrets baseline (marks existing secrets as known)
+detect-secrets scan > .secrets.baseline
+
+# Install all hooks
+pre-commit install --install-hooks
+
+# Run the full suite
+pre-commit run --all-files
+```
+
+```text
+# Expected output:
+Trim Trailing Whitespace.............................Passed
+Fix End of Files.....................................Passed
+Check Yaml...........................................Passed
+Check JSON...........................................(no files to check)Skipped
+Check for added large files..........................Passed
+Check for merge conflicts............................Passed
+Check for case conflicts.............................Passed
+Mixed line ending....................................Passed
+Detect Private Key...................................Passed
+black................................................Passed
+flake8...............................................Passed
+yamllint.............................................Passed
+shellcheck...........................................Failed
+markdownlint.........................................Passed
+terraform_fmt........................................Passed
+Detect secrets.......................................Passed
+bandit...............................................Passed
+```
+
+### Fix the Shell Script Issues
+
+```bash
+# Fix the shellcheck issues in deploy.sh
+cat > src/deploy.sh << 'SHEOF'
+#!/bin/bash
+set -euo pipefail
+
+echo "Deploying application..."
+
+if [ "${1:-}" = "production" ]; then
+    echo "Deploying to production"
+    rm -rf /tmp/deploy/*
+fi
+
+echo "Done"
+SHEOF
+```
+
+```bash
+# Verify all hooks pass now
+pre-commit run --all-files
+```
+
+```text
+# Expected output:
+Trim Trailing Whitespace.............................Passed
+Fix End of Files.....................................Passed
+Check Yaml...........................................Passed
+Check JSON...........................................(no files to check)Skipped
+Check for added large files..........................Passed
+Check for merge conflicts............................Passed
+Check for case conflicts.............................Passed
+Mixed line ending....................................Passed
+Detect Private Key...................................Passed
+black................................................Passed
+flake8...............................................Passed
+yamllint.............................................Passed
+shellcheck...........................................Passed
+markdownlint.........................................Passed
+Detect secrets.......................................Passed
+bandit...............................................Passed
+```
+
+### Checkpoint: Pre-commit Hooks
+
+```bash
+# Verify pre-commit is installed
+pre-commit --version
+# Expected: pre-commit 4.x.x
+
+# Verify hooks are installed in .git
+ls .git/hooks/pre-commit
+# Expected: .git/hooks/pre-commit
+
+# Count configured hooks
+grep -c "id:" .pre-commit-config.yaml
+# Expected: 16+ hooks
+
+# Run all hooks and verify pass
+pre-commit run --all-files && echo "All hooks pass"
+```
+
+---
+
+## Step 4: Add CI/CD Pipeline (10 min)
+
+Pre-commit catches issues locally, but CI/CD catches everything that slips through. This step
+creates a GitHub Actions workflow that validates every push and pull request.
+
+### Start with a Basic Lint Job
+
+```yaml
+# .github/workflows/ci.yml - Version 1: Basic linting
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install linters
+        run: |
+          pip install black flake8 yamllint
+          pip install shellcheck-py
+
+      - name: Run Black (check mode)
+        run: black --check .
+
+      - name: Run Flake8
+        run: flake8 --max-line-length=100 --extend-ignore=E203,W503 .
+
+      - name: Run yamllint
+        run: yamllint -d '{extends: default, rules: {line-length: {max: 120}, document-start: disable}}' .
+
+      - name: Run ShellCheck
+        run: |
+          find . -name "*.sh" -not -path "./.venv/*" | while read -r f; do
+            echo "Checking $f"
+            shellcheck "$f"
+          done
+```
+
+### Add Test and Security Jobs
+
+```yaml
+# .github/workflows/ci.yml - Version 2: Multi-job pipeline
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install black flake8 yamllint shellcheck-py
+
+      - name: Run Black (check mode)
+        run: black --check .
+
+      - name: Run Flake8
+        run: flake8 --max-line-length=100 --extend-ignore=E203,W503 .
+
+      - name: Run yamllint
+        run: yamllint -d '{extends: default, rules: {line-length: {max: 120}, document-start: disable}}' .
+
+      - name: Run ShellCheck
+        run: |
+          find . -name "*.sh" -not -path "./.venv/*" -exec shellcheck {} +
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install pytest pytest-cov
+
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ \
+            --cov=src \
+            --cov-report=term-missing \
+            --cov-fail-under=80
+
+  security:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install security tools
+        run: |
+          pip install bandit detect-secrets safety
+
+      - name: Run Bandit (Python security)
+        run: bandit -r src/ -f json -o bandit-report.json || true
+
+      - name: Run detect-secrets
+        run: |
+          detect-secrets scan --all-files --exclude-files '\.secrets\.baseline$' \
+            | python3 -c "
+          import json, sys
+          results = json.load(sys.stdin)
+          secrets = results.get('results', {})
+          total = sum(len(v) for v in secrets.values())
+          if total > 0:
+              print(f'Found {total} potential secrets:')
+              for file, findings in secrets.items():
+                  for finding in findings:
+                      print(f'  {file}:{finding[\"line_number\"]} - {finding[\"type\"]}')
+              sys.exit(1)
+          else:
+              print('No secrets detected')
+          "
+
+      - name: Upload security reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: security-reports
+          path: |
+            bandit-report.json
+          retention-days: 7
+```
+
+### Add Documentation Build Job
+
+```yaml
+# .github/workflows/ci.yml - Version 3: Full pipeline with docs
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Add UV to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Cache UV dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Sync environment
+        run: uv sync
+
+      - name: Run Black (check mode)
+        run: uv run black --check .
+
+      - name: Run Flake8
+        run: uv run flake8 --max-line-length=100 --extend-ignore=E203,W503 .
+
+      - name: Run yamllint
+        run: uv run yamllint -d '{extends: default, rules: {line-length: {max: 120}, document-start: disable}}' .
+
+      - name: Run ShellCheck
+        run: |
+          find . -name "*.sh" -not -path "./.venv/*" -exec shellcheck {} +
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Add UV to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Sync environment
+        run: uv sync
+
+      - name: Run tests with coverage
+        run: |
+          uv run pytest tests/ \
+            --cov=src \
+            --cov-report=term-missing \
+            --cov-fail-under=80
+
+  security:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install security tools
+        run: pip install bandit detect-secrets
+
+      - name: Run Bandit
+        run: bandit -r src/ -ll -ii
+
+      - name: Run detect-secrets
+        run: |
+          detect-secrets scan --all-files \
+            --exclude-files '\.secrets\.baseline$' \
+            --exclude-files '\.git/' > /tmp/secrets-scan.json
+          python3 -c "
+          import json, sys
+          results = json.load(open('/tmp/secrets-scan.json'))
+          total = sum(len(v) for v in results.get('results', {}).values())
+          if total > 0:
+              print(f'ERROR: Found {total} potential secrets')
+              sys.exit(1)
+          print('No secrets detected')
+          "
+
+  docs:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Add UV to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Sync environment
+        run: uv sync
+
+      - name: Validate metadata
+        run: uv run python scripts/validate_metadata.py docs/
+        continue-on-error: true
+
+      - name: Build documentation
+        run: uv run mkdocs build --strict
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: documentation
+          path: site/
+          retention-days: 7
+```
+
+### Visualize the Pipeline
+
+```text
+CI Pipeline Flow
+=================
+
+                    ┌──────────┐
+                    │  Push /   │
+                    │    PR     │
+                    └─────┬────┘
+                          │
+                    ┌─────▼────┐
+                    │   Lint   │  Black, Flake8, yamllint, ShellCheck
+                    └─────┬────┘
+                          │
+             ┌────────────┼────────────┐
+             │            │            │
+       ┌─────▼────┐ ┌────▼─────┐ ┌────▼────┐
+       │   Test   │ │ Security │ │  Docs   │
+       │  pytest  │ │  bandit  │ │ mkdocs  │
+       │ coverage │ │ secrets  │ │ strict  │
+       └──────────┘ └──────────┘ └─────────┘
+```
+
+### Checkpoint: CI/CD Pipeline
+
+```bash
+# Verify workflow file exists
+ls -la .github/workflows/ci.yml
+# Expected: -rw-r--r-- ... .github/workflows/ci.yml
+
+# Validate YAML syntax
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('Valid YAML')"
+# Expected: Valid YAML
+
+# Count jobs defined
+grep -c "runs-on:" .github/workflows/ci.yml
+# Expected: 4 (lint, test, security, docs)
+
+# Verify job dependencies
+grep "needs:" .github/workflows/ci.yml
+# Expected:
+#     needs: lint
+#     needs: lint
+#     needs: lint
+```
+
+---
+
+## Step 5: Enable Auto-fixes (5 min)
+
+Instead of just reporting issues, configure tools to fix them automatically. This reduces
+developer friction and speeds up the feedback loop.
+
+### Auto-fix vs Check-only Mode
+
+```bash
+# Check-only mode (CI): reports problems, exits non-zero
+black --check src/app.py
+# Output: would reformat src/app.py
+
+# Auto-fix mode (local): fixes problems in place
+black src/app.py
+# Output: reformatted src/app.py
+```
+
+```bash
+# Terraform: check-only vs auto-fix
+terraform fmt -check src/main.tf    # Check mode (CI)
+terraform fmt src/main.tf           # Auto-fix mode (local)
+```
+
+```bash
+# Markdown: check-only vs auto-fix
+markdownlint docs/                  # Check mode (CI)
+markdownlint --fix docs/            # Auto-fix mode (local)
+```
+
+### Configure Pre-commit Hooks for Auto-fix
+
+```yaml
+# .pre-commit-config.yaml - hooks that auto-fix on commit
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      # These hooks AUTO-FIX files:
+      - id: trailing-whitespace      # Removes trailing whitespace
+      - id: end-of-file-fixer        # Adds missing final newline
+      - id: mixed-line-ending        # Normalizes line endings
+        args: ['--fix=lf']
+
+  # Black AUTO-FORMATS Python files
+  - repo: https://github.com/psf/black
+    rev: 26.1.0
+    hooks:
+      - id: black
+        language_version: python3
+        # No --check flag = auto-fix mode
+
+  # Markdown linting with AUTO-FIX
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: ['--fix']  # Auto-fix mode
+
+  # Terraform AUTO-FORMAT
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
+    hooks:
+      - id: terraform_fmt  # Auto-formats .tf files
+```
+
+### Create an Auto-fix Script for Manual Use
+
+```bash
+cat > scripts/autofix.sh << 'EOF'
+#!/bin/bash
+# autofix.sh - Run all auto-fix tools
+# Use this to bulk-fix formatting issues before committing
+
+set -euo pipefail
+
+echo "============================================"
+echo "  Auto-fix: Formatting & Linting"
+echo "============================================"
+
+# Python formatting
+echo ""
+echo "[1/5] Running Black (Python formatter)..."
+if command -v black &>/dev/null; then
+    black . 2>&1 | tail -1
+else
+    echo "  Skipped: black not installed"
+fi
+
+# Terraform formatting
+echo ""
+echo "[2/5] Running terraform fmt..."
+if command -v terraform &>/dev/null; then
+    find . -name "*.tf" -not -path "./.terraform/*" -exec terraform fmt {} \;
+    echo "  Done"
+else
+    echo "  Skipped: terraform not installed"
+fi
+
+# Markdown formatting
+echo ""
+echo "[3/5] Running markdownlint --fix..."
+if command -v markdownlint &>/dev/null; then
+    markdownlint --fix "**/*.md" 2>&1 || true
+    echo "  Done"
+else
+    echo "  Skipped: markdownlint not installed"
+fi
+
+# Trailing whitespace
+echo ""
+echo "[4/5] Removing trailing whitespace..."
+find . -type f \( -name "*.py" -o -name "*.sh" -o -name "*.yaml" -o -name "*.yml" \
+    -o -name "*.tf" -o -name "*.json" -o -name "*.ts" -o -name "*.js" \) \
+    -not -path "./.venv/*" -not -path "./node_modules/*" -not -path "./.git/*" \
+    -exec sed -i.bak 's/[[:space:]]*$//' {} \;
+find . -name "*.bak" -delete 2>/dev/null || true
+echo "  Done"
+
+# Fix line endings
+echo ""
+echo "[5/5] Normalizing line endings to LF..."
+find . -type f \( -name "*.py" -o -name "*.sh" -o -name "*.yaml" -o -name "*.yml" \
+    -o -name "*.tf" -o -name "*.json" -o -name "*.ts" -o -name "*.js" -o -name "*.md" \) \
+    -not -path "./.venv/*" -not -path "./node_modules/*" -not -path "./.git/*" \
+    -exec sed -i.bak 's/\r$//' {} \;
+find . -name "*.bak" -delete 2>/dev/null || true
+echo "  Done"
+
+echo ""
+echo "============================================"
+echo "  Auto-fix complete. Review changes with:"
+echo "    git diff"
+echo "============================================"
+EOF
+chmod +x scripts/autofix.sh
+```
+
+```bash
+# Run auto-fix
+bash scripts/autofix.sh
+```
+
+```text
+# Expected output:
+============================================
+  Auto-fix: Formatting & Linting
+============================================
+
+[1/5] Running Black (Python formatter)...
+All done! 1 file reformatted.
+
+[2/5] Running terraform fmt...
+  Done
+
+[3/5] Running markdownlint --fix...
+  Done
+
+[4/5] Removing trailing whitespace...
+  Done
+
+[5/5] Normalizing line endings to LF...
+  Done
+
+============================================
+  Auto-fix complete. Review changes with:
+    git diff
+============================================
+```
+
+### Checkpoint: Auto-fixes
+
+```bash
+# Verify autofix script exists and is executable
+ls -la scripts/autofix.sh
+# Expected: -rwxr-xr-x ... scripts/autofix.sh
+
+# Run auto-fix and verify no remaining issues
+bash scripts/autofix.sh
+pre-commit run --all-files && echo "All checks pass after auto-fix"
+```
+
+---
+
+## Step 6: Add Quality Gates (5 min)
+
+Quality gates go beyond formatting to check documentation quality, spelling, links, and metrics.
+Some gates block merges; others provide advisory warnings.
+
+### Spell Checking (Blocking)
+
+```json
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "autofix",
+    "bandit",
+    "cspell",
+    "devops",
+    "editorconfig",
+    "flake8",
+    "markdownlint",
+    "mkdocs",
+    "mypy",
+    "pycqa",
+    "pytest",
+    "shellcheck",
+    "terraform",
+    "terragrunt",
+    "yamllint"
+  ],
+  "ignorePaths": [
+    "node_modules/**",
+    ".venv/**",
+    "*.lock",
+    ".git/**",
+    "site/**"
+  ]
+}
+```
+
+```bash
+# Save the config
+mkdir -p .github
+# (copy the JSON above to .github/cspell.json)
+
+# Run spell check
+cspell --config .github/cspell.json "docs/**/*.md" "*.md"
+```
+
+```text
+# Expected output (clean):
+CSpell: Files checked: 15, Issues found: 0
+```
+
+### Spell Check Workflow (Blocking Gate)
+
+```yaml
+# .github/workflows/spell-checker.yml
+name: Spell Checker
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install cSpell
+        run: npm install -g cspell
+
+      - name: Run spell check
+        run: |
+          cspell --config .github/cspell.json "docs/**/*.md" "*.md"
+```
+
+### Link Checking (Advisory)
+
+```yaml
+# .github/workflows/link-checker.yml
+name: Link Checker
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 2 * * 1'  # Weekly on Mondays
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --verbose --no-progress 'docs/**/*.md'
+          fail: false  # Advisory only, does not block merge
+```
+
+### Metadata Validation (Advisory)
+
+```bash
+# Validate @module metadata tags in documentation
+python scripts/validate_metadata.py docs/
+```
+
+```text
+# Expected output:
+Validating metadata in docs/...
+  docs/02_language_guides/python.md: OK (6 tags found)
+  docs/02_language_guides/terraform.md: OK (6 tags found)
+  ...
+Summary: 45 files checked, 42 passed, 3 warnings
+```
+
+### Code-to-Text Ratio (Advisory)
+
+```bash
+# Check that language guides maintain 3:1 code-to-text ratio
+python scripts/analyze_code_ratio.py
+```
+
+```text
+# Expected output:
+Code-to-Text Ratio Analysis
+================================================================================
+Language Guide                   Code Lines   Text Lines      Ratio     Status
+--------------------------------------------------------------------------------
+python                                 1012          318       3.18     PASS
+terraform                              2124         6285       0.34     FAIL
+ansible                                2258          330       6.84     PASS
+...
+================================================================================
+Achievement: 18/19 guides pass (target: 3:1 ratio)
+```
+
+### Quality Gate Summary
+
+```text
+Quality Gate Configuration
+===========================
+
+Gate                    | Type     | Blocks Merge? | Frequency
+------------------------+----------+---------------+------------------
+Spell Check (cSpell)    | Blocking | Yes           | Every push/PR
+Link Check (lychee)     | Advisory | No            | Weekly + push
+Metadata Validation     | Advisory | No            | Every push/PR
+Code-to-Text Ratio      | Advisory | No            | Every push/PR
+Black Formatting        | Blocking | Yes           | Every push/PR
+Flake8 Linting          | Blocking | Yes           | Every push/PR
+ShellCheck              | Blocking | Yes           | Every push/PR
+Secret Detection        | Blocking | Yes           | Every push/PR
+```
+
+### Checkpoint: Quality Gates
+
+```bash
+# Verify spell check config exists
+ls -la .github/cspell.json
+# Expected: -rw-r--r-- ... .github/cspell.json
+
+# Run spell check locally
+cspell --config .github/cspell.json "docs/**/*.md" && echo "Spelling OK"
+
+# Verify workflow files exist
+ls .github/workflows/spell-checker.yml
+ls .github/workflows/link-checker.yml
+# Both should exist
+```
+
+---
+
+## Step 7: Monitor and Measure (4 min)
+
+You cannot improve what you do not measure. Track key automation metrics to demonstrate
+value and identify bottlenecks.
+
+### Key Metrics to Track
+
+```text
+Automation Health Metrics
+==========================
+
+1. Lint Pass Rate       - % of commits that pass all linters on first try
+2. CI Duration          - Time from push to green/red status
+3. Time-to-Merge        - PR open to merge duration
+4. Pre-commit Skip Rate - How often developers run --no-verify
+5. Security Findings    - Secrets or vulnerabilities caught per month
+6. Auto-fix Rate        - % of issues fixed automatically vs manually
+```
+
+### Dashboard Script
+
+```python
+#!/usr/bin/env python3
+"""
+automation_dashboard.py - Track automation metrics from CI data.
+
+Usage:
+    python scripts/automation_dashboard.py
+"""
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta
+
+
+def run_cmd(cmd: str) -> str:
+    """Run a shell command and return stdout."""
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def get_commit_count(days: int = 30) -> int:
+    """Count commits in the last N days."""
+    since = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+    output = run_cmd(f'git log --since="{since}" --oneline')
+    return len(output.splitlines()) if output else 0
+
+
+def get_hook_skip_count(days: int = 30) -> int:
+    """Count commits that skipped pre-commit hooks."""
+    since = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+    output = run_cmd(
+        f'git log --since="{since}" --oneline --grep="no-verify" --grep="skip-hooks"'
+    )
+    return len(output.splitlines()) if output else 0
+
+
+def get_precommit_hook_count() -> int:
+    """Count configured pre-commit hooks."""
+    output = run_cmd("grep -c 'id:' .pre-commit-config.yaml 2>/dev/null")
+    return int(output) if output.isdigit() else 0
+
+
+def get_ci_workflow_count() -> int:
+    """Count CI workflow files."""
+    output = run_cmd("ls .github/workflows/*.yml 2>/dev/null | wc -l")
+    return int(output.strip()) if output.strip().isdigit() else 0
+
+
+def get_autofix_hooks() -> list[str]:
+    """List hooks that auto-fix files."""
+    autofix_hooks = [
+        "trailing-whitespace",
+        "end-of-file-fixer",
+        "mixed-line-ending",
+        "black",
+        "markdownlint --fix",
+        "terraform_fmt",
+    ]
+    configured = []
+    try:
+        with open(".pre-commit-config.yaml") as f:
+            content = f.read()
+        for hook in autofix_hooks:
+            hook_id = hook.split()[0]
+            if hook_id in content:
+                configured.append(hook)
+    except FileNotFoundError:
+        pass
+    return configured
+
+
+def print_dashboard() -> None:
+    """Print the automation dashboard."""
+    print("=" * 60)
+    print("  AUTOMATION DASHBOARD")
+    print(f"  Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print("=" * 60)
+    print()
+
+    # Commit activity
+    commits_30d = get_commit_count(30)
+    commits_7d = get_commit_count(7)
+    print(f"  Commits (last 30 days):  {commits_30d}")
+    print(f"  Commits (last 7 days):   {commits_7d}")
+    print()
+
+    # Hook metrics
+    hook_count = get_precommit_hook_count()
+    skip_count = get_hook_skip_count(30)
+    skip_rate = (skip_count / commits_30d * 100) if commits_30d > 0 else 0
+    print(f"  Pre-commit hooks:        {hook_count}")
+    print(f"  Hook skips (30 days):    {skip_count}")
+    print(f"  Skip rate:               {skip_rate:.1f}%")
+    print()
+
+    # Auto-fix hooks
+    autofix = get_autofix_hooks()
+    print(f"  Auto-fix hooks:          {len(autofix)}")
+    for hook in autofix:
+        print(f"    - {hook}")
+    print()
+
+    # CI workflows
+    workflow_count = get_ci_workflow_count()
+    print(f"  CI workflows:            {workflow_count}")
+    print()
+
+    # Automation maturity score
+    score = 0
+    if hook_count > 0:
+        score += 20
+    if hook_count >= 10:
+        score += 10
+    if workflow_count > 0:
+        score += 20
+    if workflow_count >= 3:
+        score += 10
+    if len(autofix) >= 3:
+        score += 15
+    if skip_rate < 5:
+        score += 15
+    if skip_rate == 0:
+        score += 10
+
+    print(f"  Automation Score:        {score}/100")
+    print()
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    print_dashboard()
+```
+
+```bash
+# Save the script and run it
+python scripts/automation_dashboard.py
+```
+
+```text
+# Expected output:
+============================================================
+  AUTOMATION DASHBOARD
+  Generated: 2026-02-14 10:30:00
+============================================================
+
+  Commits (last 30 days):  47
+  Commits (last 7 days):   12
+
+  Pre-commit hooks:        16
+  Hook skips (30 days):    0
+  Skip rate:               0.0%
+
+  Auto-fix hooks:          6
+    - trailing-whitespace
+    - end-of-file-fixer
+    - mixed-line-ending
+    - black
+    - markdownlint --fix
+    - terraform_fmt
+
+  CI workflows:            4
+
+  Automation Score:        100/100
+
+============================================================
+```
+
+### CI Duration Tracking with GitHub CLI
+
+```bash
+# Get recent workflow run durations
+gh run list --workflow=ci.yml --limit=10 \
+    --json conclusion,updatedAt,createdAt \
+    --jq '.[] | "\(.conclusion)\t\(.createdAt)\t\(.updatedAt)"'
+```
+
+```text
+# Expected output:
+success   2026-02-14T09:00:00Z   2026-02-14T09:03:42Z
+success   2026-02-13T15:22:00Z   2026-02-13T15:25:18Z
+failure   2026-02-13T14:10:00Z   2026-02-13T14:12:55Z
+```
+
+```bash
+# Calculate average CI duration (in seconds) for last 10 runs
+gh run list --workflow=ci.yml --limit=10 \
+    --json createdAt,updatedAt \
+    --jq '[.[] | ((.updatedAt | fromdateiso8601) - (.createdAt | fromdateiso8601))] | add / length | round'
+```
+
+### Checkpoint: Monitoring
+
+```bash
+# Verify dashboard script exists
+ls -la scripts/automation_dashboard.py
+# Expected: -rw-r--r-- ... scripts/automation_dashboard.py
+
+# Run the dashboard
+python scripts/automation_dashboard.py && echo "Dashboard works"
+```
+
+---
+
+## Automation Maturity Model
+
+Use this model to assess where your project stands and what to adopt next.
+
+```text
+Automation Maturity Model
+==========================
+
+Level | Name           | Tools & Practices                    | Time to Adopt
+------+----------------+--------------------------------------+---------------
+  0   | Manual         | Manual checklist, code review only    | 0 min
+  1   | Editor-Aware   | EditorConfig, IDE settings            | 5 min
+  2   | Pre-commit     | Pre-commit hooks, local linting       | 15 min
+  3   | CI/CD          | GitHub Actions, multi-job pipeline    | 30 min
+  4   | Auto-fix       | Auto-formatting, auto-remediation     | 10 min
+  5   | Quality Gates  | Spell check, link check, metrics      | 15 min
+```
+
+| Level | Characteristic | What Gets Caught | What Slips Through |
+|-------|---------------|------------------|-------------------|
+| 0 - Manual | Nothing automated | Whatever you remember | Everything else |
+| 1 - Editor-Aware | Formatting on save | Indentation, line endings, whitespace | Logic errors, security, naming |
+| 2 - Pre-commit | Checks before commit | Formatting, syntax, basic security | Complex logic, integration issues |
+| 3 - CI/CD | Checks on every push | Everything local + cross-platform | Quality metrics, documentation |
+| 4 - Auto-fix | Tools fix issues | Formatting auto-fixed, less friction | Non-fixable issues still require review |
+| 5 - Quality Gates | Full quality pipeline | Spelling, links, code ratios, metrics | Novel issues, architectural problems |
+
+### Mapping Tools to Maturity Levels
+
+```text
+Level 0 (Manual):
+  - scripts/manual_checks.sh
+  - Code review checklists
+
+Level 1 (Editor-Aware):
+  - .editorconfig
+  - .vscode/settings.json
+  - .idea/codeStyles/
+
+Level 2 (Pre-commit):
+  - .pre-commit-config.yaml
+  - trailing-whitespace, end-of-file-fixer
+  - black, flake8, shellcheck
+  - detect-private-key
+
+Level 3 (CI/CD):
+  - .github/workflows/ci.yml
+  - Lint, test, security, docs jobs
+  - Artifact uploads, caching
+
+Level 4 (Auto-fix):
+  - black (no --check flag)
+  - markdownlint --fix
+  - terraform fmt
+  - scripts/autofix.sh
+
+Level 5 (Quality Gates):
+  - .github/workflows/spell-checker.yml
+  - .github/workflows/link-checker.yml
+  - scripts/analyze_code_ratio.py
+  - scripts/validate_metadata.py
+  - scripts/automation_dashboard.py
+```
+
+---
+
+## Checkpoint: Final Verification
+
+Run through this complete checklist to verify your automation pipeline.
+
+```bash
+# 1. EditorConfig exists and has sections for all languages
+test -f .editorconfig && echo "PASS: .editorconfig exists" || echo "FAIL"
+
+# 2. Pre-commit hooks are installed
+test -f .git/hooks/pre-commit && echo "PASS: hooks installed" || echo "FAIL"
+
+# 3. Pre-commit config has 10+ hooks
+HOOK_COUNT=$(grep -c "id:" .pre-commit-config.yaml)
+[ "$HOOK_COUNT" -ge 10 ] && echo "PASS: $HOOK_COUNT hooks configured" || echo "FAIL: only $HOOK_COUNT hooks"
+
+# 4. CI workflow exists and is valid YAML
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" 2>/dev/null \
+    && echo "PASS: CI workflow valid" || echo "FAIL: CI workflow invalid"
+
+# 5. CI workflow has multiple jobs
+JOB_COUNT=$(grep -c "runs-on:" .github/workflows/ci.yml)
+[ "$JOB_COUNT" -ge 3 ] && echo "PASS: $JOB_COUNT CI jobs" || echo "FAIL: only $JOB_COUNT CI jobs"
+
+# 6. Spell check config exists
+test -f .github/cspell.json && echo "PASS: spell check configured" || echo "FAIL"
+
+# 7. Auto-fix script exists
+test -x scripts/autofix.sh && echo "PASS: autofix script executable" || echo "FAIL"
+
+# 8. Dashboard script exists
+test -f scripts/automation_dashboard.py && echo "PASS: dashboard exists" || echo "FAIL"
+
+# 9. All pre-commit hooks pass
+pre-commit run --all-files && echo "PASS: all hooks pass" || echo "FAIL: hooks failing"
+
+# 10. Git is clean (all fixes committed)
+[ -z "$(git status --porcelain)" ] && echo "PASS: working tree clean" || echo "WARN: uncommitted changes"
+```
+
+```text
+# Expected output:
+PASS: .editorconfig exists
+PASS: hooks installed
+PASS: 16 hooks configured
+PASS: CI workflow valid
+PASS: 4 CI jobs
+PASS: spell check configured
+PASS: autofix script executable
+PASS: dashboard exists
+PASS: all hooks pass
+PASS: working tree clean
+```
+
+---
+
+## Common Troubleshooting
+
+### Problem: Pre-commit hooks fail on first run
+
+```text
+Symptom:
+  An error occurred during hook execution.
+  The hook 'black' failed with exit code 1.
+
+Cause:
+  Hook environments are not installed yet.
+
+Solution:
+  pre-commit install --install-hooks
+  pre-commit run --all-files
+```
+
+### Problem: Black and Flake8 disagree on formatting
+
+```text
+Symptom:
+  Black formats code one way, Flake8 complains about it.
+
+Cause:
+  Flake8's E203 (whitespace before ':') and W503 (line break before binary operator)
+  conflict with Black's formatting.
+
+Solution:
+  Configure Flake8 to ignore these rules:
+    flake8 --extend-ignore=E203,W503
+
+  In .pre-commit-config.yaml:
+    - id: flake8
+      args: ['--max-line-length=100', '--extend-ignore=E203,W503']
+```
+
+### Problem: ShellCheck reports SC2086 (unquoted variables)
+
+```bash
+# Symptom:
+# In src/deploy.sh line 3:
+# if [ $1 == "production" ]; then
+#      ^-- SC2086: Double quote to prevent globbing and word splitting.
+
+# Solution: Quote variables and use = instead of ==
+# Before:
+if [ $1 == "production" ]; then
+    echo "deploying"
+fi
+
+# After:
+if [ "${1:-}" = "production" ]; then
+    echo "deploying"
+fi
+```
+
+### Problem: detect-secrets flags known safe values
+
+```bash
+# Symptom:
+# detect-secrets reports false positives on test fixtures or example configs
+
+# Solution: Update the baseline file to mark known values as safe
+detect-secrets scan --update .secrets.baseline
+
+# Then audit and mark false positives
+detect-secrets audit .secrets.baseline
+# Answer 'n' (not a real secret) for each false positive
+```
+
+### Problem: CI is too slow (over 10 minutes)
+
+```text
+Symptom:
+  CI pipeline takes 15+ minutes to complete.
+
+Causes and Solutions:
+
+1. No dependency caching
+   Fix: Add actions/cache for pip, uv, npm
+
+2. Sequential jobs that could run in parallel
+   Fix: Remove unnecessary 'needs:' dependencies
+
+3. Installing tools from scratch every run
+   Fix: Use setup-* actions with caching
+
+4. Running all checks even when only docs changed
+   Fix: Add path filters to workflow triggers
+```
+
+```yaml
+# Example: Path-filtered triggers to speed up CI
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - '.github/workflows/ci.yml'
+```
+
+### Problem: Pre-commit hooks modified files but commit still failed
+
+```text
+Symptom:
+  Pre-commit says "files were modified by this hook" and the commit fails.
+
+Cause:
+  Auto-fix hooks (black, trailing-whitespace, end-of-file-fixer) modified files.
+  Git needs the modified files to be re-staged.
+
+Solution:
+  1. Review the changes: git diff
+  2. Stage the auto-fixed files: git add -u
+  3. Commit again: git commit -m "your message"
+
+  The second commit will pass because files are already formatted.
+```
+
+### Problem: yamllint complains about line length
+
+```text
+Symptom:
+  yamllint reports "line too long (150 > 120 characters)"
+
+Solution:
+  Option 1: Break the line using YAML multiline syntax
+
+  Before:
+    description: "This is a very long description that exceeds the line length limit and causes yamllint to fail"
+
+  After:
+    description: >-
+      This is a very long description that exceeds the line length
+      limit and causes yamllint to fail
+
+  Option 2: Adjust the yamllint max line length in .pre-commit-config.yaml:
+    args: ['-d', '{extends: default, rules: {line-length: {max: 150}}}']
+```
+
+---
+
+## Next Steps
+
+After completing this tutorial, explore these resources to deepen your automation:
+
+```text
+Recommended Next Steps
+=======================
+
+1. Tutorial 1: Zero to Validated Python Project
+   - Apply automation to a real Python project
+   - See: docs/12_tutorials/python_project.md
+
+2. Tutorial 3: Full-Stack App with Multiple Languages
+   - Scale automation across Python, TypeScript, and Terraform
+   - See: docs/12_tutorials/fullstack_app.md
+
+3. CI/CD Performance Optimization Guide
+   - Advanced caching, parallelization, and pipeline tuning
+   - See: docs/05_ci_cd/ci_cd_performance.md
+
+4. Progressive Enhancement Roadmap
+   - Long-term automation adoption strategy
+   - See: docs/07_integration/progressive_enhancement.md
+
+5. Anti-Patterns Documentation
+   - Common automation mistakes and how to avoid them
+   - See: docs/08_anti_patterns/
+```
+
+```text
+Summary of What You Built
+==========================
+
+File                              Purpose
+---------------------------------+----------------------------------------
+.editorconfig                     Editor-level formatting consistency
+.pre-commit-config.yaml           Local pre-commit validation hooks
+.github/workflows/ci.yml          Server-side CI/CD pipeline
+.github/workflows/spell-checker.yml  Spelling quality gate (blocking)
+.github/workflows/link-checker.yml   Link validation (advisory)
+.github/cspell.json               Spell check configuration
+scripts/manual_checks.sh          Manual validation baseline
+scripts/autofix.sh                Bulk auto-fix formatting
+scripts/automation_dashboard.py   Automation metrics dashboard
+```

--- a/docs/12_tutorials/python_project.md
+++ b/docs/12_tutorials/python_project.md
@@ -1,0 +1,1434 @@
+---
+title: "Tutorial 1: Zero to Validated Python Project"
+description: "Build a production-ready Flask API from scratch with full validation, testing, and CI/CD in 30 minutes"
+author: "Tyler Dukes"
+tags: [tutorial, python, flask, testing, ci-cd, validation, beginner, uv, pre-commit]
+category: "Tutorials"
+status: "active"
+---
+
+<!-- markdownlint-disable MD013 -->
+
+## Overview
+
+### What You Will Build
+
+A production-ready Flask REST API for task management with:
+
+- Application factory pattern
+- Typed data models
+- CRUD endpoints with error handling
+- Health check endpoint
+- Full test suite
+- Pre-commit validation hooks
+- GitHub Actions CI/CD pipeline
+- Dukes-compliant metadata on all source files
+
+```text
+my-flask-api/
+├── pyproject.toml
+├── .editorconfig
+├── .pre-commit-config.yaml
+├── .github/
+│   └── workflows/
+│       └── ci.yml
+├── src/
+│   └── my_flask_api/
+│       ├── __init__.py
+│       ├── app.py
+│       ├── config.py
+│       ├── models.py
+│       └── routes.py
+└── tests/
+    ├── __init__.py
+    ├── conftest.py
+    └── test_routes.py
+```
+
+### Estimated Time
+
+30 minutes.
+
+### Prerequisites
+
+```bash
+# Verify prerequisites
+python3 --version   # Python 3.11+
+git --version       # Git 2.30+
+uv --version        # uv 0.4+
+```
+
+```bash
+# Install uv if not already installed
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+---
+
+## Step 1: Project Setup (5 min)
+
+### Create the Project Directory
+
+```bash
+# Create project and navigate into it
+mkdir my-flask-api && cd my-flask-api
+
+# Initialize git repository
+git init
+
+# Create the source and test directories
+mkdir -p src/my_flask_api tests .github/workflows
+```
+
+### Initialize with pyproject.toml
+
+```toml
+# pyproject.toml
+[project]
+name = "my-flask-api"
+version = "0.1.0"
+description = "A production-ready Flask REST API following Dukes Engineering Style Guide"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [
+    { name = "Your Name", email = "you@example.com" },
+]
+dependencies = [
+    "flask>=3.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3.0",
+    "pytest-cov>=6.0.0",
+    "black>=24.10.0",
+    "flake8>=7.1.0",
+    "pre-commit>=4.0.0",
+]
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short --strict-markers"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/my_flask_api"]
+```
+
+### Install Dependencies
+
+```bash
+# Create virtual environment and install all dependencies
+uv sync --all-extras
+
+# Verify installation
+uv run python -c "import flask; print(f'Flask {flask.__version__}')"
+uv run pytest --version
+uv run black --version
+```
+
+```text
+# Expected output (versions may vary)
+Flask 3.1.0
+pytest 8.3.4
+black, 24.10.0 (compiled: yes)
+```
+
+### Checkpoint: Project Setup
+
+```bash
+# Verify project structure
+ls pyproject.toml src/my_flask_api tests .github/workflows
+```
+
+```text
+# Expected output
+pyproject.toml
+
+src/my_flask_api:
+
+tests:
+
+.github/workflows:
+```
+
+---
+
+## Step 2: Create Flask API (10 min)
+
+### Configuration Module
+
+```python
+# src/my_flask_api/config.py
+"""
+@module config
+@description Application configuration for Flask API with environment-based settings
+@version 0.1.0
+@author Your Name
+@last_updated 2026-02-14
+@status stable
+"""
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Config:
+    """Base configuration."""
+
+    TESTING: bool = False
+    DEBUG: bool = False
+    SECRET_KEY: str = os.environ.get("SECRET_KEY", "change-me-in-production")
+
+
+@dataclass(frozen=True)
+class DevelopmentConfig(Config):
+    """Development configuration."""
+
+    DEBUG: bool = True
+
+
+@dataclass(frozen=True)
+class TestingConfig(Config):
+    """Testing configuration."""
+
+    TESTING: bool = True
+    DEBUG: bool = True
+
+
+@dataclass(frozen=True)
+class ProductionConfig(Config):
+    """Production configuration."""
+
+    SECRET_KEY: str = os.environ.get("SECRET_KEY", "")
+
+    def __post_init__(self) -> None:
+        if not self.SECRET_KEY:
+            raise ValueError("SECRET_KEY must be set in production")
+
+
+CONFIG_MAP: dict[str, type[Config]] = {
+    "development": DevelopmentConfig,
+    "testing": TestingConfig,
+    "production": ProductionConfig,
+}
+
+
+def get_config(env: str | None = None) -> Config:
+    """Return configuration for the given environment.
+
+    Args:
+        env: Environment name. Defaults to FLASK_ENV or 'development'.
+
+    Returns:
+        Configuration instance for the specified environment.
+    """
+    env = env or os.environ.get("FLASK_ENV", "development")
+    config_class = CONFIG_MAP.get(env, DevelopmentConfig)
+    return config_class()
+```
+
+### Data Models
+
+```python
+# src/my_flask_api/models.py
+"""
+@module models
+@description Typed data models for the task management API
+@version 0.1.0
+@author Your Name
+@last_updated 2026-02-14
+@status stable
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+
+class TaskStatus(str, Enum):
+    """Valid task statuses."""
+
+    TODO = "todo"
+    IN_PROGRESS = "in_progress"
+    DONE = "done"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class Task:
+    """Represents a single task in the system."""
+
+    title: str
+    description: str = ""
+    status: TaskStatus = TaskStatus.TODO
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    updated_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def to_dict(self) -> dict:
+        """Serialize task to dictionary."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "status": self.status.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Task:
+        """Deserialize task from dictionary.
+
+        Args:
+            data: Dictionary with task fields.
+
+        Returns:
+            A Task instance.
+
+        Raises:
+            ValueError: If required fields are missing or status is invalid.
+        """
+        if "title" not in data:
+            raise ValueError("Field 'title' is required")
+
+        status_value = data.get("status", TaskStatus.TODO.value)
+        try:
+            status = TaskStatus(status_value)
+        except ValueError:
+            valid = ", ".join(s.value for s in TaskStatus)
+            raise ValueError(f"Invalid status '{status_value}'. Must be one of: {valid}")
+
+        return cls(
+            title=data["title"],
+            description=data.get("description", ""),
+            status=status,
+            id=data.get("id", str(uuid.uuid4())),
+        )
+
+
+class TaskStore:
+    """In-memory task storage."""
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, Task] = {}
+
+    def list_all(self) -> list[dict]:
+        """Return all tasks as dictionaries."""
+        return [task.to_dict() for task in self._tasks.values()]
+
+    def get(self, task_id: str) -> Task | None:
+        """Return a task by ID, or None if not found."""
+        return self._tasks.get(task_id)
+
+    def create(self, task: Task) -> Task:
+        """Store a new task and return it."""
+        self._tasks[task.id] = task
+        return task
+
+    def update(self, task_id: str, data: dict) -> Task | None:
+        """Update an existing task. Returns None if not found."""
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+
+        if "title" in data:
+            task.title = data["title"]
+        if "description" in data:
+            task.description = data["description"]
+        if "status" in data:
+            try:
+                task.status = TaskStatus(data["status"])
+            except ValueError:
+                valid = ", ".join(s.value for s in TaskStatus)
+                raise ValueError(f"Invalid status. Must be one of: {valid}")
+
+        task.updated_at = datetime.now(timezone.utc).isoformat()
+        return task
+
+    def delete(self, task_id: str) -> bool:
+        """Delete a task by ID. Returns True if deleted, False if not found."""
+        if task_id in self._tasks:
+            del self._tasks[task_id]
+            return True
+        return False
+```
+
+### Route Handlers
+
+```python
+# src/my_flask_api/routes.py
+"""
+@module routes
+@description Flask route handlers for the task management API
+@version 0.1.0
+@author Your Name
+@last_updated 2026-02-14
+@status stable
+"""
+
+from flask import Blueprint, jsonify, request
+
+from my_flask_api.models import Task, TaskStore
+
+api = Blueprint("api", __name__, url_prefix="/api")
+
+# In-memory store (replace with database in production)
+store = TaskStore()
+
+
+@api.route("/health", methods=["GET"])
+def health_check():
+    """Return service health status."""
+    return jsonify({"status": "healthy", "service": "my-flask-api", "version": "0.1.0"})
+
+
+@api.route("/tasks", methods=["GET"])
+def list_tasks():
+    """Return all tasks."""
+    tasks = store.list_all()
+    return jsonify({"tasks": tasks, "count": len(tasks)})
+
+
+@api.route("/tasks", methods=["POST"])
+def create_task():
+    """Create a new task from JSON body."""
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({"error": "Request body must be valid JSON"}), 400
+
+    try:
+        task = Task.from_dict(data)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    store.create(task)
+    return jsonify(task.to_dict()), 201
+
+
+@api.route("/tasks/<task_id>", methods=["GET"])
+def get_task(task_id: str):
+    """Return a single task by ID."""
+    task = store.get(task_id)
+    if task is None:
+        return jsonify({"error": f"Task '{task_id}' not found"}), 404
+    return jsonify(task.to_dict())
+
+
+@api.route("/tasks/<task_id>", methods=["PUT"])
+def update_task(task_id: str):
+    """Update an existing task."""
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({"error": "Request body must be valid JSON"}), 400
+
+    try:
+        task = store.update(task_id, data)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    if task is None:
+        return jsonify({"error": f"Task '{task_id}' not found"}), 404
+    return jsonify(task.to_dict())
+
+
+@api.route("/tasks/<task_id>", methods=["DELETE"])
+def delete_task(task_id: str):
+    """Delete a task by ID."""
+    deleted = store.delete(task_id)
+    if not deleted:
+        return jsonify({"error": f"Task '{task_id}' not found"}), 404
+    return jsonify({"message": f"Task '{task_id}' deleted"}), 200
+```
+
+### Application Factory
+
+```python
+# src/my_flask_api/app.py
+"""
+@module app
+@description Flask application factory for the task management API
+@version 0.1.0
+@author Your Name
+@last_updated 2026-02-14
+@status stable
+"""
+
+from flask import Flask
+
+from my_flask_api.config import get_config
+from my_flask_api.routes import api
+
+
+def create_app(env: str | None = None) -> Flask:
+    """Create and configure the Flask application.
+
+    Args:
+        env: Environment name ('development', 'testing', 'production').
+             Defaults to FLASK_ENV or 'development'.
+
+    Returns:
+        Configured Flask application instance.
+    """
+    app = Flask(__name__)
+    config = get_config(env)
+
+    app.config.from_mapping(
+        TESTING=config.TESTING,
+        DEBUG=config.DEBUG,
+        SECRET_KEY=config.SECRET_KEY,
+    )
+
+    app.register_blueprint(api)
+
+    @app.errorhandler(404)
+    def not_found(error):
+        return {"error": "Resource not found"}, 404
+
+    @app.errorhandler(405)
+    def method_not_allowed(error):
+        return {"error": "Method not allowed"}, 405
+
+    @app.errorhandler(500)
+    def internal_error(error):
+        return {"error": "Internal server error"}, 500
+
+    return app
+```
+
+### Package Init
+
+```python
+# src/my_flask_api/__init__.py
+"""
+@module my_flask_api
+@description Task management REST API built with Flask
+@version 0.1.0
+@author Your Name
+@last_updated 2026-02-14
+@status stable
+"""
+
+from my_flask_api.app import create_app
+
+__all__ = ["create_app"]
+```
+
+### Checkpoint: Flask API
+
+```bash
+# Start the development server
+uv run flask --app my_flask_api.app:create_app run --port 5000 &
+
+# Wait for server to start
+sleep 2
+
+# Test health endpoint
+curl -s http://localhost:5000/api/health | python3 -m json.tool
+```
+
+```json
+{
+    "service": "my-flask-api",
+    "status": "healthy",
+    "version": "0.1.0"
+}
+```
+
+```bash
+# Test creating a task
+curl -s -X POST http://localhost:5000/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Write tests", "description": "Add pytest test suite"}' \
+  | python3 -m json.tool
+```
+
+```json
+{
+    "id": "a1b2c3d4-...",
+    "title": "Write tests",
+    "description": "Add pytest test suite",
+    "status": "todo",
+    "created_at": "2026-02-14T12:00:00+00:00",
+    "updated_at": "2026-02-14T12:00:00+00:00"
+}
+```
+
+```bash
+# Test listing tasks
+curl -s http://localhost:5000/api/tasks | python3 -m json.tool
+```
+
+```json
+{
+    "tasks": [
+        {
+            "id": "a1b2c3d4-...",
+            "title": "Write tests",
+            "description": "Add pytest test suite",
+            "status": "todo",
+            "created_at": "2026-02-14T12:00:00+00:00",
+            "updated_at": "2026-02-14T12:00:00+00:00"
+        }
+    ],
+    "count": 1
+}
+```
+
+```bash
+# Test error handling (missing title)
+curl -s -X POST http://localhost:5000/api/tasks \
+  -H "Content-Type: application/json" \
+  -d '{"description": "no title"}' \
+  | python3 -m json.tool
+```
+
+```json
+{
+    "error": "Field 'title' is required"
+}
+```
+
+```bash
+# Stop the development server
+kill %1
+```
+
+---
+
+## Step 3: Add Metadata (3 min)
+
+Every source file already includes the `@module` metadata block in its docstring. This is the standard format required by the Dukes Engineering Style Guide.
+
+### Metadata Format Reference
+
+```python
+# Required tags for all source files
+"""
+@module module_name              # lowercase, underscores/hyphens only
+@description Brief purpose       # one-line description
+@version 0.1.0                   # semantic versioning (MAJOR.MINOR.PATCH)
+@author Your Name                # author name
+@last_updated 2026-02-14         # ISO 8601 date
+@status stable                   # draft | in-progress | review | stable | deprecated | archived
+"""
+```
+
+### Validate Metadata
+
+```bash
+# If you have the Dukes style guide tools available:
+# python scripts/validate_metadata.py src/
+
+# Quick manual check - ensure all files have @module tags
+grep -r "@module" src/my_flask_api/
+```
+
+```text
+# Expected output
+src/my_flask_api/__init__.py:@module my_flask_api
+src/my_flask_api/app.py:@module app
+src/my_flask_api/config.py:@module config
+src/my_flask_api/models.py:@module models
+src/my_flask_api/routes.py:@module routes
+```
+
+---
+
+## Step 4: Configure Validation Tools (5 min)
+
+### EditorConfig
+
+```ini
+# .editorconfig
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+```
+
+### Pre-commit Configuration
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--unsafe]
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=1000]
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  - repo: https://github.com/psf/black
+    rev: "24.10.0"
+    hooks:
+      - id: black
+        args: [--line-length=100]
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: "7.1.1"
+    hooks:
+      - id: flake8
+        args: [--max-line-length=100, --extend-ignore=E203,W503]
+```
+
+### Install and Verify Pre-commit Hooks
+
+```bash
+# Install pre-commit hooks into the git repository
+uv run pre-commit install
+
+# Run all hooks against all files
+uv run pre-commit run --all-files
+```
+
+```text
+# Expected output
+Trim Trailing Whitespace.................................................Passed
+Fix End of Files.........................................................Passed
+Check Yaml...............................................................Passed
+Check JSON...........................................(no files to check)Skipped
+Check for added large files..............................................Passed
+Check for merge conflicts................................................Passed
+Detect Private Key.......................................................Passed
+black....................................................................Passed
+flake8...................................................................Passed
+```
+
+### Flake8 Configuration
+
+```toml
+# Add to pyproject.toml (append to existing file)
+[tool.flake8]
+max-line-length = 100
+extend-ignore = ["E203", "W503"]
+exclude = [".git", "__pycache__", ".venv", "build", "dist"]
+```
+
+> **Note**: Flake8 does not natively read `pyproject.toml`. The pre-commit hook above passes the arguments directly. For local usage, create a `.flake8` file:
+
+```ini
+# .flake8
+[flake8]
+max-line-length = 100
+extend-ignore = E203,W503
+exclude = .git,__pycache__,.venv,build,dist
+```
+
+### Checkpoint: Validation Tools
+
+```bash
+# Format all code with black
+uv run black src/ tests/
+
+# Lint all code with flake8
+uv run flake8 src/ tests/
+
+# Run pre-commit on all files
+uv run pre-commit run --all-files
+```
+
+```text
+# All three commands should complete with no errors
+```
+
+---
+
+## Step 5: Write Tests (5 min)
+
+### Test Init
+
+```python
+# tests/__init__.py
+```
+
+### Test Fixtures
+
+```python
+# tests/conftest.py
+"""
+@module conftest
+@description Shared pytest fixtures for the task management API test suite
+@version 0.1.0
+@author Your Name
+@last_updated 2026-02-14
+@status stable
+"""
+
+import pytest
+
+from my_flask_api.app import create_app
+
+
+@pytest.fixture()
+def app():
+    """Create application instance configured for testing."""
+    app = create_app(env="testing")
+    yield app
+
+
+@pytest.fixture()
+def client(app):
+    """Create a test client for the Flask application."""
+    return app.test_client()
+
+
+@pytest.fixture()
+def sample_task_data():
+    """Return sample task data for creating test tasks."""
+    return {
+        "title": "Implement authentication",
+        "description": "Add JWT-based authentication to the API",
+        "status": "todo",
+    }
+```
+
+### Route Tests
+
+```python
+# tests/test_routes.py
+"""
+@module test_routes
+@description Tests for all API route handlers including health, CRUD, and error cases
+@version 0.1.0
+@author Your Name
+@last_updated 2026-02-14
+@status stable
+"""
+
+import json
+
+
+class TestHealthEndpoint:
+    """Tests for the /api/health endpoint."""
+
+    def test_health_returns_200(self, client):
+        """Health endpoint returns 200 with status healthy."""
+        response = client.get("/api/health")
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert data["status"] == "healthy"
+        assert data["service"] == "my-flask-api"
+        assert data["version"] == "0.1.0"
+
+
+class TestCreateTask:
+    """Tests for POST /api/tasks."""
+
+    def test_create_task_success(self, client, sample_task_data):
+        """Creating a valid task returns 201 with task data."""
+        response = client.post(
+            "/api/tasks",
+            data=json.dumps(sample_task_data),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+
+        data = response.get_json()
+        assert data["title"] == sample_task_data["title"]
+        assert data["description"] == sample_task_data["description"]
+        assert data["status"] == "todo"
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_create_task_missing_title(self, client):
+        """Creating a task without a title returns 400."""
+        response = client.post(
+            "/api/tasks",
+            data=json.dumps({"description": "no title provided"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert "title" in response.get_json()["error"].lower()
+
+    def test_create_task_invalid_json(self, client):
+        """Sending invalid JSON returns 400."""
+        response = client.post(
+            "/api/tasks",
+            data="not json",
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_create_task_invalid_status(self, client):
+        """Creating a task with an invalid status returns 400."""
+        response = client.post(
+            "/api/tasks",
+            data=json.dumps({"title": "Test", "status": "invalid"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert "status" in response.get_json()["error"].lower()
+
+
+class TestListTasks:
+    """Tests for GET /api/tasks."""
+
+    def test_list_tasks_empty(self, client):
+        """Listing tasks when none exist returns empty list."""
+        response = client.get("/api/tasks")
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert data["tasks"] == []
+        assert data["count"] == 0
+
+    def test_list_tasks_after_create(self, client, sample_task_data):
+        """Listing tasks after creating one returns the task."""
+        client.post(
+            "/api/tasks",
+            data=json.dumps(sample_task_data),
+            content_type="application/json",
+        )
+
+        response = client.get("/api/tasks")
+        data = response.get_json()
+        assert data["count"] == 1
+        assert data["tasks"][0]["title"] == sample_task_data["title"]
+
+
+class TestGetTask:
+    """Tests for GET /api/tasks/<task_id>."""
+
+    def test_get_task_success(self, client, sample_task_data):
+        """Getting a task by valid ID returns the task."""
+        create_resp = client.post(
+            "/api/tasks",
+            data=json.dumps(sample_task_data),
+            content_type="application/json",
+        )
+        task_id = create_resp.get_json()["id"]
+
+        response = client.get(f"/api/tasks/{task_id}")
+        assert response.status_code == 200
+        assert response.get_json()["id"] == task_id
+
+    def test_get_task_not_found(self, client):
+        """Getting a nonexistent task returns 404."""
+        response = client.get("/api/tasks/nonexistent-id")
+        assert response.status_code == 404
+
+
+class TestUpdateTask:
+    """Tests for PUT /api/tasks/<task_id>."""
+
+    def test_update_task_success(self, client, sample_task_data):
+        """Updating a task changes its fields and returns 200."""
+        create_resp = client.post(
+            "/api/tasks",
+            data=json.dumps(sample_task_data),
+            content_type="application/json",
+        )
+        task_id = create_resp.get_json()["id"]
+
+        response = client.put(
+            f"/api/tasks/{task_id}",
+            data=json.dumps({"title": "Updated title", "status": "in_progress"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert data["title"] == "Updated title"
+        assert data["status"] == "in_progress"
+
+    def test_update_task_not_found(self, client):
+        """Updating a nonexistent task returns 404."""
+        response = client.put(
+            "/api/tasks/nonexistent-id",
+            data=json.dumps({"title": "Nope"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+    def test_update_task_invalid_status(self, client, sample_task_data):
+        """Updating a task with an invalid status returns 400."""
+        create_resp = client.post(
+            "/api/tasks",
+            data=json.dumps(sample_task_data),
+            content_type="application/json",
+        )
+        task_id = create_resp.get_json()["id"]
+
+        response = client.put(
+            f"/api/tasks/{task_id}",
+            data=json.dumps({"status": "bogus"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+
+class TestDeleteTask:
+    """Tests for DELETE /api/tasks/<task_id>."""
+
+    def test_delete_task_success(self, client, sample_task_data):
+        """Deleting an existing task returns 200 and removes it."""
+        create_resp = client.post(
+            "/api/tasks",
+            data=json.dumps(sample_task_data),
+            content_type="application/json",
+        )
+        task_id = create_resp.get_json()["id"]
+
+        response = client.delete(f"/api/tasks/{task_id}")
+        assert response.status_code == 200
+
+        # Verify the task is gone
+        get_resp = client.get(f"/api/tasks/{task_id}")
+        assert get_resp.status_code == 404
+
+    def test_delete_task_not_found(self, client):
+        """Deleting a nonexistent task returns 404."""
+        response = client.delete("/api/tasks/nonexistent-id")
+        assert response.status_code == 404
+```
+
+### Run Tests
+
+```bash
+# Run the full test suite with verbose output
+uv run pytest tests/ -v
+```
+
+```text
+# Expected output
+tests/test_routes.py::TestHealthEndpoint::test_health_returns_200 PASSED
+tests/test_routes.py::TestCreateTask::test_create_task_success PASSED
+tests/test_routes.py::TestCreateTask::test_create_task_missing_title PASSED
+tests/test_routes.py::TestCreateTask::test_create_task_invalid_json PASSED
+tests/test_routes.py::TestCreateTask::test_create_task_invalid_status PASSED
+tests/test_routes.py::TestListTasks::test_list_tasks_empty PASSED
+tests/test_routes.py::TestListTasks::test_list_tasks_after_create PASSED
+tests/test_routes.py::TestGetTask::test_get_task_success PASSED
+tests/test_routes.py::TestGetTask::test_get_task_not_found PASSED
+tests/test_routes.py::TestUpdateTask::test_update_task_success PASSED
+tests/test_routes.py::TestUpdateTask::test_update_task_not_found PASSED
+tests/test_routes.py::TestUpdateTask::test_update_task_invalid_status PASSED
+tests/test_routes.py::TestDeleteTask::test_delete_task_success PASSED
+tests/test_routes.py::TestDeleteTask::test_delete_task_not_found PASSED
+
+14 passed in 0.25s
+```
+
+```bash
+# Run with coverage report
+uv run pytest tests/ --cov=my_flask_api --cov-report=term-missing
+```
+
+```text
+# Expected output
+Name                          Stmts   Miss  Cover   Missing
+------------------------------------------------------------
+src/my_flask_api/__init__.py      2      0   100%
+src/my_flask_api/app.py          18      3    83%   34-39
+src/my_flask_api/config.py       24      2    92%   37-38
+src/my_flask_api/models.py       52      0   100%
+src/my_flask_api/routes.py       38      0   100%
+------------------------------------------------------------
+TOTAL                           134      5    96%
+```
+
+### Checkpoint: Tests
+
+```bash
+# All 14 tests should pass
+uv run pytest tests/ -v --tb=short
+```
+
+---
+
+## Step 6: Set Up CI/CD (5 min)
+
+### GitHub Actions Workflow
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Check formatting with black
+        run: uv run black --check --diff src/ tests/
+
+      - name: Lint with flake8
+        run: uv run flake8 src/ tests/
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests with coverage
+        run: uv run pytest tests/ -v --cov=my_flask_api --cov-report=term-missing
+
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Verify metadata tags
+        run: |
+          grep -r "@module" src/my_flask_api/ | wc -l | xargs -I{} test {} -ge 5
+          echo "All source files contain @module metadata"
+
+      - name: Run pre-commit hooks
+        run: |
+          uv run pre-commit install
+          uv run pre-commit run --all-files
+```
+
+### Checkpoint: CI Configuration
+
+```bash
+# Validate the workflow YAML syntax
+python3 -c "
+import yaml
+with open('.github/workflows/ci.yml') as f:
+    config = yaml.safe_load(f)
+print(f'Jobs defined: {list(config[\"jobs\"].keys())}')
+print('Workflow YAML is valid')
+"
+```
+
+```text
+# Expected output
+Jobs defined: ['lint', 'test', 'validate']
+Workflow YAML is valid
+```
+
+---
+
+## Step 7: Verify Everything Works (2 min)
+
+### Run the Full Validation Suite
+
+```bash
+# 1. Format code
+uv run black src/ tests/
+
+# 2. Lint code
+uv run flake8 src/ tests/
+
+# 3. Run all tests
+uv run pytest tests/ -v
+
+# 4. Run pre-commit hooks
+uv run pre-commit run --all-files
+
+# 5. Verify metadata is present in all source files
+grep -r "@module" src/my_flask_api/
+```
+
+```text
+# Expected: All commands exit with code 0, all tests pass, all hooks pass
+```
+
+### Make Your First Commit
+
+```bash
+# Stage all files
+git add .
+
+# Commit following conventional commit format
+git commit -m "feat: initial Flask API with full validation
+
+- Application factory pattern with environment-based config
+- Task CRUD endpoints with typed models and error handling
+- Health check endpoint
+- 14 pytest tests with 96% coverage
+- Pre-commit hooks (black, flake8, trailing whitespace)
+- GitHub Actions CI with lint, test (3.11-3.13), and validate jobs
+- Dukes-compliant @module metadata on all source files"
+```
+
+```text
+# Expected: pre-commit hooks run and pass, commit succeeds
+Trim Trailing Whitespace.................................................Passed
+Fix End of Files.........................................................Passed
+Check Yaml...............................................................Passed
+Check for added large files..............................................Passed
+Check for merge conflicts................................................Passed
+Detect Private Key.......................................................Passed
+black....................................................................Passed
+flake8...................................................................Passed
+[main (root-commit) abc1234] feat: initial Flask API with full validation
+ 12 files changed, 450 insertions(+)
+```
+
+---
+
+## Checkpoint: Final Verification
+
+Use this checklist to confirm everything is working:
+
+```text
+Final Verification Checklist
+============================
+[ ] pyproject.toml has project metadata and tool configuration
+[ ] .editorconfig enforces consistent formatting
+[ ] .pre-commit-config.yaml has hooks for formatting, linting, and file checks
+[ ] .flake8 has line length and ignore rules matching black
+[ ] .github/workflows/ci.yml has lint, test, and validate jobs
+
+[ ] src/my_flask_api/__init__.py exports create_app
+[ ] src/my_flask_api/app.py has application factory with error handlers
+[ ] src/my_flask_api/config.py has environment-based dataclass configs
+[ ] src/my_flask_api/models.py has Task, TaskStatus, and TaskStore
+[ ] src/my_flask_api/routes.py has health + full CRUD endpoints
+
+[ ] All 5 source files have @module metadata comments
+[ ] All @module tags include: module, description, version, author, last_updated, status
+
+[ ] tests/conftest.py has app, client, and sample_task_data fixtures
+[ ] tests/test_routes.py has 14 tests covering all endpoints and error cases
+[ ] uv run pytest tests/ -v shows 14 passed
+
+[ ] uv run black --check src/ tests/ passes with no changes
+[ ] uv run flake8 src/ tests/ passes with no errors
+[ ] uv run pre-commit run --all-files shows all hooks passed
+
+[ ] git log shows at least one conventional commit
+```
+
+```bash
+# Quick automated check
+echo "=== Tests ===" && uv run pytest tests/ -q \
+  && echo "=== Black ===" && uv run black --check src/ tests/ \
+  && echo "=== Flake8 ===" && uv run flake8 src/ tests/ \
+  && echo "=== Metadata ===" && grep -rc "@module" src/my_flask_api/*.py \
+  && echo "=== ALL CHECKS PASSED ==="
+```
+
+```text
+# Expected output
+=== Tests ===
+14 passed in 0.25s
+=== Black ===
+All done! 6 files would be left unchanged.
+=== Flake8 ===
+=== Metadata ===
+src/my_flask_api/__init__.py:1
+src/my_flask_api/app.py:1
+src/my_flask_api/config.py:1
+src/my_flask_api/models.py:1
+src/my_flask_api/routes.py:1
+=== ALL CHECKS PASSED ===
+```
+
+---
+
+## Common Troubleshooting
+
+### Problem: `ModuleNotFoundError: No module named 'my_flask_api'`
+
+```bash
+# Cause: The package is not installed in the virtual environment
+# Solution: Ensure pyproject.toml has the correct build configuration and reinstall
+uv sync --all-extras
+
+# Verify the package is installed
+uv run pip list | grep my-flask-api
+```
+
+```text
+# Expected output
+my-flask-api    0.1.0
+```
+
+### Problem: Black and flake8 disagree on formatting
+
+```bash
+# Cause: Line length or ignore rules are mismatched
+# Solution: Ensure both tools use the same line length and flake8 ignores E203, W503
+
+# In pyproject.toml:
+# [tool.black]
+# line-length = 100
+
+# In .flake8:
+# max-line-length = 100
+# extend-ignore = E203,W503
+
+# Reformat and re-lint
+uv run black src/ tests/ && uv run flake8 src/ tests/
+```
+
+### Problem: Pre-commit hooks fail on first run
+
+```bash
+# Cause: Hook environments haven't been installed yet
+# Solution: Install hooks explicitly
+uv run pre-commit install --install-hooks
+
+# Retry running hooks
+uv run pre-commit run --all-files
+```
+
+### Problem: Tests fail with `fixture 'client' not found`
+
+```bash
+# Cause: conftest.py is not in the tests directory or has a syntax error
+# Solution: Verify the file exists and is valid Python
+python3 -c "import ast; ast.parse(open('tests/conftest.py').read()); print('conftest.py is valid')"
+
+# Verify pytest discovers the fixtures
+uv run pytest tests/ --fixtures | grep -A2 "client"
+```
+
+```text
+# Expected output
+client -- tests/conftest.py:19
+    Create a test client for the Flask application.
+```
+
+### Problem: Flask app fails to start with `ImportError`
+
+```bash
+# Cause: Running flask directly instead of through the installed package
+# Solution: Always use uv run to ensure the correct environment
+
+# Wrong
+flask run
+
+# Correct
+uv run flask --app my_flask_api.app:create_app run
+```
+
+### Problem: CI workflow fails with `uv: command not found`
+
+```yaml
+# Cause: uv is not installed in the CI environment
+# Solution: Add the astral-sh/setup-uv action before any uv commands
+
+# In .github/workflows/ci.yml, ensure this step comes first:
+steps:
+  - uses: actions/checkout@v4
+
+  - name: Install uv
+    uses: astral-sh/setup-uv@v5
+    with:
+      enable-cache: true
+```
+
+### Problem: Git commit rejected by pre-commit hooks
+
+```bash
+# Cause: Code has formatting or linting issues
+# Solution: Let the tools fix what they can, then review remaining issues
+
+# Auto-fix formatting
+uv run black src/ tests/
+
+# Check for remaining lint errors
+uv run flake8 src/ tests/
+
+# Re-stage files that were modified by black
+git add -u
+
+# Retry the commit
+git commit -m "feat: your commit message"
+```
+
+---
+
+## Next Steps
+
+After completing this tutorial, continue your learning path:
+
+- **[Tutorial 2: Migrating Existing Terraform Module](terraform_migration.md)** -- Apply the Dukes style to infrastructure code with CONTRACT.md and automated testing.
+- **[Tutorial 3: Full-Stack App with Multiple Languages](fullstack_app.md)** -- Combine Python, TypeScript, and Terraform in a single validated project.
+- **[Python Style Guide](../02_language_guides/python.md)** -- Deep dive into all Python standards including type hints, docstrings, and advanced patterns.
+- **[CONTRACT.md Template](../04_templates/contract_template.md)** -- Learn contract-based development for reusable modules.
+- **[IaC Testing Standards](../05_ci_cd/iac_testing_standards.md)** -- Full CI/CD pipeline standards and testing strategies.

--- a/docs/12_tutorials/team_onboarding.md
+++ b/docs/12_tutorials/team_onboarding.md
@@ -1,0 +1,1213 @@
+---
+title: "Tutorial 4: Team Onboarding"
+description: "Get your entire team up and running with the Dukes Engineering Style Guide in 20 minutes"
+author: "Tyler Dukes"
+tags: [tutorial, onboarding, team, getting-started, setup, pre-commit, editor]
+category: "Tutorials"
+status: "active"
+---
+
+<!-- markdownlint-disable MD013 -->
+
+## Overview
+
+This tutorial gets your team from zero to fully configured in 20 minutes. By the end, every developer on your team will have consistent formatting, automated linting, and shared editor settings -- no manual style debates required.
+
+```text
+Time Estimate
+=============
+Step 1: Install Core Tools ........... 5 min
+Step 2: Configure Your Editor ........ 5 min
+Step 3: Set Up Pre-commit Hooks ...... 3 min
+Step 4: Learn the Key Patterns ....... 5 min
+Step 5: Validate Your First Change ... 2 min
+                                      ------
+Total ................................ 20 min
+```
+
+### Prerequisites
+
+```bash
+# All you need to start
+git --version    # Git 2.30+
+code --version   # VS Code (or IntelliJ IDEA)
+```
+
+```text
+No Python experience required.
+No Terraform experience required.
+No infrastructure knowledge required.
+Just git and an editor.
+```
+
+---
+
+## Step 1: Install Core Tools (5 min)
+
+### Install uv (Python Package Manager)
+
+```bash
+# macOS
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Verify installation
+uv --version
+```
+
+```bash
+# Expected output
+# uv 0.6.x (or newer)
+```
+
+### Install pre-commit
+
+```bash
+# Using uv (recommended)
+uv tool install pre-commit
+
+# Or using pip
+pip install pre-commit
+
+# Verify installation
+pre-commit --version
+```
+
+```bash
+# Expected output
+# pre-commit 4.x.x (or newer)
+```
+
+### Install Language-Specific Linters
+
+```bash
+# macOS - install all recommended linters
+brew install shellcheck          # Shell script linting
+brew install terraform           # Terraform formatting
+brew install yamllint            # YAML linting
+brew install markdownlint-cli    # Markdown linting
+npm install -g cspell            # Spell checking
+```
+
+```bash
+# Linux (Debian/Ubuntu) - install all recommended linters
+sudo apt-get update && sudo apt-get install -y shellcheck
+
+# Terraform
+wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt-get update && sudo apt-get install -y terraform
+
+# yamllint
+pip install yamllint
+
+# markdownlint
+npm install -g markdownlint-cli
+
+# Spell checking
+npm install -g cspell
+```
+
+### Checkpoint 1
+
+```bash
+# Verify all tools are installed
+echo "=== Tool Verification ==="
+uv --version        && echo "uv: OK"
+pre-commit --version && echo "pre-commit: OK"
+shellcheck --version | head -1 && echo "shellcheck: OK"
+terraform --version  | head -1 && echo "terraform: OK"
+yamllint --version   && echo "yamllint: OK"
+```
+
+```text
+Expected output (versions may vary):
+=== Tool Verification ===
+uv 0.6.x
+uv: OK
+pre-commit 4.x.x
+pre-commit: OK
+ShellCheck, version 0.10.x
+shellcheck: OK
+Terraform v1.x.x
+terraform: OK
+yamllint 1.x.x
+yamllint: OK
+```
+
+---
+
+## Step 2: Configure Your Editor (5 min)
+
+### Option A: VS Code (Recommended)
+
+```bash
+# Clone the style guide repo (if you have not already)
+git clone https://github.com/tydukes/coding-style-guide.git
+cd coding-style-guide
+
+# Copy editor settings to your project
+cp -r .vscode/ /path/to/your-project/.vscode/
+cp .editorconfig /path/to/your-project/.editorconfig
+```
+
+```bash
+# Install all recommended extensions in one command
+cat .vscode/extensions.json | \
+  python3 -c "import sys,json; [print(e) for e in json.load(sys.stdin)['recommendations']]" | \
+  xargs -I {} code --install-extension {}
+```
+
+```bash
+# Or install the critical extensions individually
+code --install-extension ms-python.python
+code --install-extension ms-python.black-formatter
+code --install-extension ms-python.flake8
+code --install-extension redhat.vscode-yaml
+code --install-extension DavidAnson.vscode-markdownlint
+code --install-extension timonwong.shellcheck
+code --install-extension hashicorp.terraform
+code --install-extension EditorConfig.EditorConfig
+code --install-extension streetsidesoftware.code-spell-checker
+code --install-extension esbenp.prettier-vscode
+```
+
+Key settings that ship with `.vscode/settings.json`:
+
+```json
+{
+  "editor.formatOnSave": true,
+  "editor.rulers": [100],
+  "python.formatting.provider": "black",
+  "python.linting.flake8Enabled": true,
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.tabSize": 4
+  },
+  "[yaml]": {
+    "editor.tabSize": 2
+  },
+  "[terraform]": {
+    "editor.defaultFormatter": "hashicorp.terraform",
+    "editor.tabSize": 2
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.tabSize": 2
+  },
+  "[markdown]": {
+    "editor.tabSize": 2,
+    "files.trimTrailingWhitespace": false
+  }
+}
+```
+
+### Option B: IntelliJ IDEA / PyCharm
+
+```bash
+# Copy IntelliJ settings to your project
+cp -r .idea/ /path/to/your-project/.idea/
+cp .editorconfig /path/to/your-project/.editorconfig
+```
+
+```text
+IntelliJ settings include:
+- Code style settings matching pre-commit hooks
+- Inspection profiles for all languages
+- Auto-format on save configuration
+- EditorConfig support enabled
+```
+
+```xml
+<!-- .idea/codeStyles/Project.xml key settings -->
+<code_scheme name="Project" version="173">
+  <option name="RIGHT_MARGIN" value="100" />
+  <PythonCodeStyleSettings>
+    <option name="SPACE_AFTER_NUMBER_SIGN" value="true" />
+  </PythonCodeStyleSettings>
+  <codeStyleSettings language="Python">
+    <option name="RIGHT_MARGIN" value="100" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="4" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="YAML">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>
+```
+
+### Verify EditorConfig Is Working
+
+```bash
+# Create a test file in your project
+cat > /tmp/editorconfig-test.py << 'PYEOF'
+def hello():
+    print("EditorConfig is working")
+PYEOF
+```
+
+```text
+Open the file in your editor. You should see:
+- Python files: 4-space indentation
+- YAML files: 2-space indentation
+- Line endings: LF (not CRLF)
+- Final newline: automatically inserted on save
+- Trailing whitespace: automatically removed on save
+```
+
+### Checkpoint 2
+
+```bash
+# Verify .editorconfig exists in your project
+ls -la /path/to/your-project/.editorconfig
+
+# Verify .vscode settings exist
+ls -la /path/to/your-project/.vscode/settings.json
+ls -la /path/to/your-project/.vscode/extensions.json
+
+# Verify EditorConfig extension is installed
+code --list-extensions | grep -i editorconfig
+```
+
+```text
+Expected output:
+-rw-r--r--  1 user  staff  .editorconfig
+-rw-r--r--  1 user  staff  .vscode/settings.json
+-rw-r--r--  1 user  staff  .vscode/extensions.json
+EditorConfig.EditorConfig
+```
+
+---
+
+## Step 3: Set Up Pre-commit Hooks (3 min)
+
+### Install Hooks in Your Existing Repo
+
+```bash
+# Navigate to your project
+cd /path/to/your-project
+
+# Copy the pre-commit config from the style guide
+cp /path/to/coding-style-guide/.pre-commit-config.yaml .
+```
+
+```yaml
+# .pre-commit-config.yaml - what you just copied
+repos:
+  # General file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ['--unsafe']
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+      - id: detect-private-key
+
+  # Python formatting and linting
+  - repo: https://github.com/psf/black
+    rev: 26.1.0
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: ['--max-line-length=100', '--extend-ignore=E203,W503']
+
+  # YAML linting
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: ['-d', '{extends: default, rules: {line-length: {max: 120}, document-start: disable}}']
+
+  # Shell script linting
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  # Markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: ['--fix']
+```
+
+### Install and Run
+
+```bash
+# Install the hooks (downloads hook environments)
+pre-commit install --install-hooks
+
+# Run against ALL existing files (first-time baseline)
+pre-commit run --all-files
+```
+
+```text
+Expected first-run output:
+Trim Trailing Whitespace...............................Passed
+Fix End of Files.......................................Passed
+Check Yaml.............................................Passed
+Check JSON.............................................Passed
+Check for added large files............................Passed
+Check for merge conflicts..............................Passed
+Check for case conflicts...............................Passed
+Mixed line ending......................................Passed
+Detect Private Key.....................................Passed
+black..................................................Failed
+- hook id: black
+- files were reformatted
+flake8.................................................Failed
+- hook id: flake8
+yamllint...............................................Passed
+shellcheck.............................................Passed
+markdownlint...........................................Failed
+- hook id: markdownlint
+```
+
+### Fix Initial Issues
+
+```bash
+# Black auto-fixes formatting -- just re-add and commit
+git add -A
+pre-commit run --all-files
+
+# If flake8 still fails, check specific errors
+pre-commit run flake8 --all-files 2>&1 | head -20
+```
+
+```bash
+# Common flake8 fixes
+# E501: line too long (break long lines)
+# E302: expected 2 blank lines (add blank lines between top-level definitions)
+# F401: imported but unused (remove unused imports)
+# W291: trailing whitespace (black usually fixes this)
+```
+
+```bash
+# Markdownlint common fixes
+# MD013: Line length > 120 characters (add line breaks)
+# MD033: Inline HTML (use markdown syntax instead)
+# MD041: First line should be a top-level heading
+```
+
+### Checkpoint 3
+
+```bash
+# All hooks should pass now
+pre-commit run --all-files
+
+# Verify hooks are installed for future commits
+ls .git/hooks/pre-commit
+```
+
+```text
+Expected output:
+Trim Trailing Whitespace...............................Passed
+Fix End of Files.......................................Passed
+Check Yaml.............................................Passed
+Check JSON.............................................Passed
+Check for added large files............................Passed
+Check for merge conflicts..............................Passed
+Check for case conflicts...............................Passed
+Mixed line ending......................................Passed
+Detect Private Key.....................................Passed
+black..................................................Passed
+flake8.................................................Passed
+yamllint...............................................Passed
+shellcheck.............................................Passed
+markdownlint...........................................Passed
+```
+
+---
+
+## Step 4: Learn the Key Patterns (5 min)
+
+### Naming Conventions Per Language
+
+```text
+Language        Files                  Variables            Functions/Methods
+----------      -------------------    -----------------    ---------------------
+Python          snake_case.py          snake_case           snake_case
+TypeScript      kebab-case.ts          camelCase            camelCase
+Terraform       kebab-case.tf          snake_case           N/A (use locals)
+Bash            kebab-case.sh          UPPER_SNAKE_CASE     snake_case
+YAML            kebab-case.yaml        kebab-case keys      N/A
+Kubernetes      kebab-case.yaml        kebab-case labels    N/A
+Dockerfile      Dockerfile             UPPER_SNAKE_CASE     N/A
+Makefile        Makefile               UPPER_SNAKE_CASE     snake_case (targets)
+```
+
+### Indentation Rules
+
+```text
+Language        Style      Size    Max Line Length
+---------       ------     ----    ---------------
+Python          spaces     4       100
+TypeScript      spaces     2       100
+Terraform       spaces     2       120
+Bash            spaces     2       100
+YAML            spaces     2       120
+JSON            spaces     2       N/A
+Makefile        tabs       4       100
+Go              tabs       4       100
+```
+
+### Metadata Tags
+
+Every source file should include metadata in a comment block:
+
+```python
+"""
+@module user_service
+@description Handles user authentication and profile management
+@version 1.2.0
+@author Tyler Dukes
+@last_updated 2025-06-15
+@status stable
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+```hcl
+# @module vpc_network
+# @description Creates a VPC with public and private subnets
+# @version 2.0.0
+# @author Tyler Dukes
+# @last_updated 2025-06-15
+# @status stable
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+}
+```
+
+```bash
+#!/usr/bin/env bash
+# @module deploy_script
+# @description Deploys application to staging environment
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-06-15
+# @status stable
+
+set -euo pipefail
+```
+
+```yaml
+# @module ci_pipeline
+# @description Main CI/CD pipeline configuration
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-06-15
+# @status stable
+
+name: CI Pipeline
+on:
+  push:
+    branches: [main]
+```
+
+```typescript
+/**
+ * @module api_router
+ * @description Express router for REST API endpoints
+ * @version 1.1.0
+ * @author Tyler Dukes
+ * @last_updated 2025-06-15
+ * @status stable
+ */
+
+import express from "express";
+
+const router = express.Router();
+```
+
+### Code Block Language Tags
+
+Always use language tags in markdown code blocks. This is enforced by markdownlint.
+
+```markdown
+<!-- CORRECT: language tag specified -->
+
+    ```python
+    def hello():
+        print("world")
+    ```
+
+    ```bash
+    echo "hello world"
+    ```
+
+    ```yaml
+    name: CI Pipeline
+    on: push
+    ```
+
+    ```hcl
+    resource "aws_s3_bucket" "main" {
+      bucket = "my-bucket"
+    }
+    ```
+
+<!-- INCORRECT: bare code block (will fail linting) -->
+
+    ```
+    def hello():
+        print("world")
+    ```
+```
+
+### Before and After: Python
+
+```python
+# BEFORE: Non-compliant
+import os, sys
+from datetime import datetime,timedelta
+
+def getData(userID):
+  data = {"name":"John","age":30,"email":"john@example.com","address":"123 Main St","city":"Springfield","state":"IL"}
+  if data["name"]=="John":
+    return data
+  else:
+    return None
+
+class user_manager:
+  def __init__(self):
+    self.users=[]
+  def AddUser(self,user):
+    self.users.append(user)
+```
+
+```python
+# AFTER: Compliant with Dukes Style Guide
+"""
+@module user_data
+@description User data retrieval and management
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-06-15
+@status stable
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+
+def get_data(user_id: str) -> dict | None:
+    """Retrieve user data by ID."""
+    data = {
+        "name": "John",
+        "age": 30,
+        "email": "john@example.com",
+        "address": "123 Main St",
+        "city": "Springfield",
+        "state": "IL",
+    }
+    if data["name"] == "John":
+        return data
+    return None
+
+
+class UserManager:
+    """Manages user lifecycle operations."""
+
+    def __init__(self) -> None:
+        self.users: list[dict] = []
+
+    def add_user(self, user: dict) -> None:
+        """Add a user to the managed collection."""
+        self.users.append(user)
+```
+
+### Before and After: Terraform
+
+```hcl
+# BEFORE: Non-compliant
+resource "aws_s3_bucket" "MyBucket" {
+bucket = "my-app-bucket"
+tags = {
+Name = "my-app"
+Environment = "prod"
+}
+}
+
+variable "bucketName" {
+  default = "my-app-bucket"
+}
+```
+
+```hcl
+# AFTER: Compliant with Dukes Style Guide
+# @module s3_storage
+# @description S3 bucket for application assets
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-06-15
+# @status stable
+
+resource "aws_s3_bucket" "my_bucket" {
+  bucket = var.bucket_name
+
+  tags = {
+    Name        = "my-app"
+    Environment = "prod"
+    ManagedBy   = "terraform"
+  }
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket for application assets"
+  type        = string
+  default     = "my-app-bucket"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.bucket_name))
+    error_message = "Bucket name must be lowercase alphanumeric with hyphens or dots."
+  }
+}
+```
+
+### Before and After: Bash
+
+```bash
+# BEFORE: Non-compliant
+#!/bin/bash
+echo "deploying..."
+cd /app
+rm -rf node_modules
+npm install
+npm run build
+cp -r dist/* /var/www/html
+echo "done"
+```
+
+```bash
+# AFTER: Compliant with Dukes Style Guide
+#!/usr/bin/env bash
+# @module deploy_app
+# @description Build and deploy frontend application
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-06-15
+# @status stable
+
+set -euo pipefail
+
+readonly APP_DIR="/app"
+readonly BUILD_DIR="${APP_DIR}/dist"
+readonly DEPLOY_DIR="/var/www/html"
+
+main() {
+  echo "INFO: Starting deployment..."
+
+  if [[ ! -d "${APP_DIR}" ]]; then
+    echo "ERROR: Application directory not found: ${APP_DIR}" >&2
+    exit 1
+  fi
+
+  cd "${APP_DIR}"
+  rm -rf node_modules
+  npm ci --production
+  npm run build
+
+  if [[ ! -d "${BUILD_DIR}" ]]; then
+    echo "ERROR: Build output not found: ${BUILD_DIR}" >&2
+    exit 1
+  fi
+
+  cp -r "${BUILD_DIR}"/* "${DEPLOY_DIR}"/
+  echo "INFO: Deployment complete."
+}
+
+main "$@"
+```
+
+### Checkpoint 4
+
+```text
+Quick self-check -- can you answer these?
+
+1. Python file names use _________ case.       (snake_case)
+2. Python indentation is ___ spaces.            (4)
+3. YAML indentation is ___ spaces.              (2)
+4. Every code block in markdown needs a ______. (language tag)
+5. Required metadata tags: @module, @_________, @_________
+                           (description, version)
+```
+
+---
+
+## Step 5: Validate Your First Change (2 min)
+
+### Make a Small Change
+
+```bash
+# Create a test Python file in your project
+cat > test_style.py << 'EOF'
+"""
+@module test_style
+@description Validates style guide compliance
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2025-06-15
+@status stable
+"""
+
+
+def greet(name: str) -> str:
+    """Return a greeting message."""
+    return f"Hello, {name}!"
+
+
+if __name__ == "__main__":
+    print(greet("Team"))
+EOF
+```
+
+### Commit and See Hooks Run
+
+```bash
+# Stage the file
+git add test_style.py
+
+# Commit -- pre-commit hooks run automatically
+git commit -m "feat: add style compliance test file"
+```
+
+```text
+Expected output:
+Trim Trailing Whitespace...............................Passed
+Fix End of Files.......................................Passed
+Check Yaml..........................................(no files to check)Skipped
+Check JSON..........................................(no files to check)Skipped
+Check for added large files............................Passed
+Check for merge conflicts..............................Passed
+Check for case conflicts...............................Passed
+Mixed line ending......................................Passed
+Detect Private Key.....................................Passed
+black..................................................Passed
+flake8.................................................Passed
+[main abc1234] feat: add style compliance test file
+ 1 file changed, 17 insertions(+)
+ create mode 100644 test_style.py
+```
+
+### Clean Up
+
+```bash
+# Remove the test file
+git rm test_style.py
+git commit -m "chore: remove style compliance test file"
+```
+
+### Checkpoint 5
+
+```bash
+# Verify hooks ran successfully on your commit
+git log --oneline -2
+```
+
+```text
+Expected output:
+abc1234 chore: remove style compliance test file
+def5678 feat: add style compliance test file
+```
+
+---
+
+## Quick Reference Card
+
+```text
+==========================================================================
+  DUKES ENGINEERING STYLE GUIDE -- QUICK REFERENCE
+==========================================================================
+
+  PYTHON
+  ------
+  Formatter:   black (100 char line)
+  Linter:      flake8 (ignore E203, W503)
+  Indent:      4 spaces
+  Naming:      snake_case (files, vars, funcs), PascalCase (classes)
+  Imports:     One per line, stdlib -> third-party -> local
+
+  TERRAFORM
+  ---------
+  Formatter:   terraform fmt
+  Indent:      2 spaces
+  Naming:      snake_case (resources, vars), kebab-case (files)
+  Structure:   main.tf, variables.tf, outputs.tf, versions.tf
+  Tags:        Always include Name, Environment, ManagedBy
+
+  TYPESCRIPT
+  ----------
+  Formatter:   prettier
+  Linter:      eslint
+  Indent:      2 spaces
+  Naming:      camelCase (vars, funcs), PascalCase (classes, interfaces)
+  Files:       kebab-case.ts
+
+  BASH
+  ----
+  Linter:      shellcheck
+  Indent:      2 spaces
+  Shebang:     #!/usr/bin/env bash
+  Safety:      set -euo pipefail (always)
+  Naming:      UPPER_SNAKE_CASE (vars), snake_case (functions)
+  Structure:   main() pattern, functions before calls
+
+  YAML
+  ----
+  Linter:      yamllint (120 char line)
+  Indent:      2 spaces
+  Naming:      kebab-case (keys)
+  Booleans:    true/false (not yes/no, on/off)
+  Strings:     Quote when ambiguous
+
+  ALL LANGUAGES
+  -------------
+  Line endings:       LF (not CRLF)
+  Final newline:      Always
+  Trailing spaces:    Never (except markdown)
+  Code blocks:        Always use language tags
+  Metadata:           @module, @description, @version (minimum)
+  Commits:            Conventional format: type(scope): subject
+
+==========================================================================
+```
+
+```text
+==========================================================================
+  CONVENTIONAL COMMIT TYPES
+==========================================================================
+
+  feat:      New feature
+  fix:       Bug fix
+  docs:      Documentation only
+  style:     Formatting (no code change)
+  refactor:  Code restructuring (no feature/fix)
+  test:      Adding or updating tests
+  chore:     Maintenance tasks
+  ci:        CI/CD configuration changes
+  perf:      Performance improvements
+  build:     Build system or dependency changes
+  revert:    Reverting a previous commit
+
+  Format:    type(scope): short description
+  Example:   feat(auth): add JWT token refresh endpoint
+  Breaking:  feat(api)!: remove deprecated v1 endpoints
+
+==========================================================================
+```
+
+---
+
+## Common Troubleshooting
+
+### Problem 1: pre-commit install fails with "command not found"
+
+```bash
+# Symptom
+$ pre-commit install
+zsh: command not found: pre-commit
+
+# Cause: pre-commit is not on your PATH
+
+# Fix (option 1): Install with uv
+uv tool install pre-commit
+# uv puts tools in ~/.local/bin -- make sure it is on PATH
+export PATH="$HOME/.local/bin:$PATH"
+
+# Fix (option 2): Install with pip
+pip install pre-commit
+
+# Fix (option 3): Use pipx
+pipx install pre-commit
+
+# Verify
+pre-commit --version
+```
+
+### Problem 2: Black reformats files but commit still fails
+
+```bash
+# Symptom: black reformats files, but commit is rejected
+
+# Cause: Black modifies files in-place during the hook.
+# The modified files are not staged, so the commit has stale content.
+
+# Fix: Re-add the reformatted files and commit again
+git add -u
+git commit -m "style: apply black formatting"
+```
+
+```bash
+# Prevention: Use this alias to auto-stage after hooks
+git config --local alias.cc '!git add -u && git commit'
+
+# Then use:
+git cc -m "feat: my new feature"
+```
+
+### Problem 3: Flake8 reports "E501 line too long" but Black did not fix it
+
+```bash
+# Symptom
+test.py:42:101: E501 line too long (145 > 100 characters)
+
+# Cause: Black formats to 88 chars by default, but our config uses 100.
+# However, some lines (like URLs or long strings) cannot be split by Black.
+
+# Fix: Break the long line manually
+# Before:
+result = some_function(very_long_argument_name, another_long_argument, yet_another_parameter, final_param="value")
+
+# After:
+result = some_function(
+    very_long_argument_name,
+    another_long_argument,
+    yet_another_parameter,
+    final_param="value",
+)
+```
+
+```bash
+# For URLs or strings that cannot be broken, use noqa:
+DOCS_URL = "https://example.com/very/long/path/to/documentation/page"  # noqa: E501
+```
+
+### Problem 4: yamllint fails with "wrong indentation"
+
+```yaml
+# Symptom
+# config.yaml:5:3 [error] wrong indentation: expected 2 but found 4
+
+# Cause: Mixed indentation in YAML file
+
+# WRONG (4-space indent):
+services:
+    web:
+        image: nginx
+
+# CORRECT (2-space indent):
+services:
+  web:
+    image: nginx
+```
+
+```bash
+# Fix: Let your editor handle it
+# With EditorConfig installed, YAML files auto-indent at 2 spaces.
+# Re-indent the file in VS Code:
+# 1. Open the file
+# 2. Cmd+Shift+P (or Ctrl+Shift+P)
+# 3. Type "Reindent Lines"
+# 4. Save
+```
+
+### Problem 5: shellcheck reports SC2086 "double quote to prevent globbing"
+
+```bash
+# Symptom
+# deploy.sh:10:3 SC2086: Double quote to prevent globbing and word splitting.
+
+# WRONG:
+FILE_PATH=$1
+cat $FILE_PATH
+
+# CORRECT:
+FILE_PATH="$1"
+cat "${FILE_PATH}"
+```
+
+```bash
+# Common shellcheck fixes:
+# SC2086: Always double-quote variables
+echo "${MY_VAR}"              # not: echo $MY_VAR
+
+# SC2034: Variable appears unused (if exported or used later)
+export MY_VAR="value"         # Add export, or use in script
+
+# SC2155: Declare and assign separately
+local exit_code               # Declare first
+exit_code="$(command)"        # Then assign
+
+# SC2164: Use || exit after cd
+cd "${DIR}" || exit 1         # not: cd $DIR
+```
+
+### Problem 6: markdownlint fails with MD033 "Inline HTML"
+
+```markdown
+<!-- Symptom -->
+<!-- MD033/no-inline-html: Inline HTML [Element: br] -->
+
+<!-- WRONG: -->
+Line one<br>Line two
+
+<!-- CORRECT: -->
+Line one
+
+Line two
+```
+
+```markdown
+<!-- If you need HTML for a specific reason, disable the rule inline: -->
+<!-- markdownlint-disable MD033 -->
+<details>
+<summary>Click to expand</summary>
+
+Content here.
+
+</details>
+<!-- markdownlint-enable MD033 -->
+```
+
+### Problem 7: EditorConfig not applying settings
+
+```bash
+# Symptom: Files save with wrong indentation or line endings
+
+# Check 1: Is the EditorConfig extension installed?
+code --list-extensions | grep -i editorconfig
+# Should show: EditorConfig.EditorConfig
+
+# Check 2: Is .editorconfig in the project root?
+ls -la .editorconfig
+
+# Check 3: Does .editorconfig have root = true?
+head -3 .editorconfig
+# Should show:
+# root = true
+```
+
+```bash
+# Fix: Install the extension and reload VS Code
+code --install-extension EditorConfig.EditorConfig
+
+# Then reload VS Code:
+# Cmd+Shift+P -> "Developer: Reload Window"
+```
+
+---
+
+## Next Steps
+
+```text
+Recommended next tutorials:
+
+For Python developers:
+  Tutorial 1: Zero to Validated Python Project (30 min)
+  -> docs/12_tutorials/python_project.md
+
+For Infrastructure engineers:
+  Tutorial 2: Migrating Existing Terraform Module (45 min)
+  -> docs/12_tutorials/terraform_migration.md
+
+For Team leads:
+  Tutorial 5: From Manual to Automated (40 min)
+  -> docs/12_tutorials/manual_to_automated.md
+```
+
+```text
+Recommended reading:
+
+Language-specific guides:
+  Python:      docs/02_language_guides/python.md
+  Terraform:   docs/02_language_guides/terraform.md
+  TypeScript:  docs/02_language_guides/typescript.md
+  Bash:        docs/02_language_guides/bash.md
+  YAML:        docs/02_language_guides/yaml.md
+
+Templates:
+  CONTRACT.md:           docs/04_templates/contract_template.md
+  Language guide:         docs/04_templates/language_guide_template.md
+  IDE settings:           docs/04_templates/ide_settings_template.md
+
+Standards:
+  Documentation:          docs/00_standards/
+  Metadata schema:        docs/03_metadata_schema/
+  Anti-patterns:          docs/08_anti_patterns/
+```
+
+### Share With Your Team
+
+```bash
+# Create a team setup script that new members can run
+cat > setup-style-guide.sh << 'BASH'
+#!/usr/bin/env bash
+# @module setup_style_guide
+# @description One-command team onboarding for Dukes Engineering Style Guide
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2025-06-15
+# @status stable
+
+set -euo pipefail
+
+echo "=== Dukes Engineering Style Guide Setup ==="
+
+# Install pre-commit
+if ! command -v pre-commit &> /dev/null; then
+  echo "Installing pre-commit..."
+  pip install pre-commit
+fi
+
+# Install hooks
+echo "Installing pre-commit hooks..."
+pre-commit install --install-hooks
+
+# Install VS Code extensions (if VS Code is available)
+if command -v code &> /dev/null; then
+  echo "Installing VS Code extensions..."
+  code --install-extension EditorConfig.EditorConfig
+  code --install-extension ms-python.black-formatter
+  code --install-extension ms-python.flake8
+  code --install-extension redhat.vscode-yaml
+  code --install-extension DavidAnson.vscode-markdownlint
+  code --install-extension timonwong.shellcheck
+  code --install-extension hashicorp.terraform
+  code --install-extension streetsidesoftware.code-spell-checker
+fi
+
+# Run initial validation
+echo "Running initial validation..."
+pre-commit run --all-files || true
+
+echo ""
+echo "=== Setup Complete ==="
+echo "Pre-commit hooks are installed and will run on every commit."
+echo "See: https://tydukes.github.io/coding-style-guide/"
+BASH
+
+chmod +x setup-style-guide.sh
+```
+
+```bash
+# New team members just run:
+./setup-style-guide.sh
+```

--- a/docs/12_tutorials/terraform_migration.md
+++ b/docs/12_tutorials/terraform_migration.md
@@ -1,0 +1,2071 @@
+---
+title: "Tutorial 2: Migrating Existing Terraform Module (45 min)"
+description: "Step-by-step tutorial for migrating a legacy Terraform VPC module to full Dukes Engineering Style Guide compliance"
+author: "Tyler Dukes"
+tags: [tutorial, terraform, migration, iac, contract, terratest, vpc, compliance]
+category: "Tutorials"
+status: "active"
+---
+
+<!-- markdownlint-disable MD013 -->
+
+## Overview
+
+This tutorial walks through taking a real-world, messy Terraform VPC module and bringing it to full compliance with the Dukes Engineering Style Guide. You will fix formatting, add validation, write a CONTRACT.md, add metadata, create Terratest tests, and set up CI/CD.
+
+### What You Will Build
+
+```text
+Before                              After
+======                              =====
+vpc-module/                         terraform-aws-vpc/
+  main.tf (600 lines, messy)          main.tf
+  vars.tf (no descriptions)           variables.tf
+                                      outputs.tf
+                                      versions.tf
+                                      locals.tf
+                                      CONTRACT.md
+                                      README.md
+                                      test/
+                                        vpc_test.go
+                                        fixtures/
+                                          main.tf
+                                      .github/
+                                        workflows/
+                                          ci.yml
+```
+
+### Estimated Time
+
+```text
+Step 1: Assess the Legacy Module       5 min
+Step 2: Apply Formatting Standards      5 min
+Step 3: Add Variable Validation         5 min
+Step 4: Write CONTRACT.md              10 min
+Step 5: Add Metadata                    3 min
+Step 6: Write Terratest Tests          10 min
+Step 7: Set Up CI/CD                    5 min
+Step 8: Publish to Registry             2 min
+─────────────────────────────────────────────
+Total                                  45 min
+```
+
+### Prerequisites
+
+```bash
+# Verify required tools
+terraform version   # Terraform 1.6+
+go version          # Go 1.21+
+git version         # Git 2.30+
+aws --version       # AWS CLI 2.x (for plan/apply)
+```
+
+```bash
+# Install terratest (Go module)
+go install github.com/gruntwork-io/terratest@latest
+
+# Install terraform-docs
+brew install terraform-docs    # macOS
+# or
+go install github.com/terraform-docs/terraform-docs@latest
+```
+
+---
+
+## Step 1: Assess the Legacy Module (5 min)
+
+Below is the legacy module you are migrating. This is a typical "grown organically" module with common problems: everything in one file, no descriptions, hardcoded values, inconsistent naming, and no documentation.
+
+### The "Before" State
+
+```hcl
+# vpc-module/main.tf - THE ENTIRE MODULE IN ONE FILE
+# Created by: someone on the team, a while ago
+# TODO: clean this up
+
+terraform {
+required_version = ">= 1.0"
+required_providers {
+aws = {
+  source = "hashicorp/aws"
+  version = "~> 4.0"
+}
+}
+}
+
+variable "cidr" {}
+variable "Name" {}
+variable "env" {
+  default = "dev"
+}
+variable "AZs" {
+  type = list(string)
+  default = ["us-east-1a","us-east-1b"]
+}
+variable "publicSubnets" {
+  default = ["10.0.1.0/24","10.0.2.0/24"]
+}
+variable "private_subnets" {
+  default = ["10.0.10.0/24","10.0.11.0/24"]
+}
+variable "enable_nat" {
+  default = true
+}
+variable "tags" {
+  default = {}
+}
+
+resource "aws_vpc" "vpc" {
+cidr_block = var.cidr
+enable_dns_hostnames = true
+enable_dns_support = true
+tags = merge(var.tags, {
+Name = var.Name
+Environment = var.env
+})
+}
+
+resource "aws_internet_gateway" "igw" {
+vpc_id = aws_vpc.vpc.id
+tags = {
+Name = "${var.Name}-igw"
+}
+}
+
+resource "aws_subnet" "public" {
+count = length(var.publicSubnets)
+vpc_id = aws_vpc.vpc.id
+cidr_block = var.publicSubnets[count.index]
+availability_zone = var.AZs[count.index]
+map_public_ip_on_launch = true
+tags = {
+"Name" = "${var.Name}-public-${count.index}"
+}
+}
+
+resource "aws_subnet" "private" {
+count = length(var.private_subnets)
+vpc_id = aws_vpc.vpc.id
+cidr_block = var.private_subnets[count.index]
+availability_zone = var.AZs[count.index]
+tags = {
+"Name" = "${var.Name}-private-${count.index}"
+}
+}
+
+resource "aws_eip" "nat" {
+count = var.enable_nat ? 1 : 0
+vpc = true
+}
+
+resource "aws_nat_gateway" "nat" {
+count = var.enable_nat ? 1 : 0
+allocation_id = aws_eip.nat[0].id
+subnet_id = aws_subnet.public[0].id
+tags = {
+Name = "${var.Name}-nat"
+}
+}
+
+resource "aws_route_table" "public" {
+vpc_id = aws_vpc.vpc.id
+route {
+cidr_block = "0.0.0.0/0"
+gateway_id = aws_internet_gateway.igw.id
+}
+tags = {
+Name = "${var.Name}-public-rt"
+}
+}
+
+resource "aws_route_table" "private" {
+count = var.enable_nat ? 1 : 0
+vpc_id = aws_vpc.vpc.id
+route {
+cidr_block = "0.0.0.0/0"
+nat_gateway_id = aws_nat_gateway.nat[0].id
+}
+tags = {
+Name = "${var.Name}-private-rt"
+}
+}
+
+resource "aws_route_table_association" "public" {
+count = length(var.publicSubnets)
+subnet_id = aws_subnet.public[count.index].id
+route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+count = var.enable_nat ? length(var.private_subnets) : 0
+subnet_id = aws_subnet.private[count.index].id
+route_table_id = aws_route_table.private[0].id
+}
+
+output "vpc_id" {
+value = aws_vpc.vpc.id
+}
+output "public_subnets" {
+value = aws_subnet.public[*].id
+}
+output "private_subnets" {
+value = aws_subnet.private[*].id
+}
+```
+
+### Identify the Problems
+
+```text
+Issue                           Severity    Style Guide Violation
+──────────────────────────────────────────────────────────────────
+No indentation / bad formatting HIGH        Terraform Style Guide: Formatting
+Mixed naming (camelCase + snake) HIGH       Terraform Style Guide: Naming
+No variable descriptions        HIGH        Terraform Style Guide: Variables
+No variable validation          MEDIUM      Terraform Style Guide: Validation
+Everything in one file          HIGH        Terraform Style Guide: File Layout
+No type constraints on vars     MEDIUM      Terraform Style Guide: Variables
+No output descriptions          MEDIUM      Terraform Style Guide: Outputs
+No CONTRACT.md                  HIGH        CONTRACT.md Template
+No metadata tags                MEDIUM      Metadata Schema
+No tests                        HIGH        IaC Testing Standards
+No CI/CD pipeline               MEDIUM      CI/CD Standards
+Deprecated `vpc = true` on EIP  HIGH        Provider deprecation (use domain)
+Hardcoded provider version ~>4  MEDIUM      Should use latest major
+No versions.tf file             MEDIUM      Terraform Style Guide: File Layout
+```
+
+### Checkpoint 1
+
+```bash
+# Clone or create the legacy module to work with
+mkdir -p terraform-aws-vpc
+cd terraform-aws-vpc
+git init
+
+# Create the legacy main.tf (copy the code above)
+# Verify the starting state
+terraform fmt -check -diff .
+# Expected: formatting differences reported (non-zero exit code)
+echo $?
+# Expected output: 3
+```
+
+---
+
+## Step 2: Apply Formatting Standards (5 min)
+
+### 2.1 Run terraform fmt
+
+```bash
+# Auto-format all .tf files
+terraform fmt -recursive .
+
+# Verify formatting is clean
+terraform fmt -check -diff .
+echo $?
+# Expected output: 0
+```
+
+### 2.2 Split Into Standard File Layout
+
+```hcl
+# versions.tf - Provider and Terraform version constraints
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+```
+
+```hcl
+# variables.tf - All input variables with descriptions, types, and defaults
+variable "vpc_name" {
+  description = "Name prefix for all VPC resources"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC (e.g., 10.0.0.0/16)"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, production)"
+  type        = string
+  default     = "dev"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones for subnet distribution"
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets (one per AZ)"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets (one per AZ)"
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.11.0/24"]
+}
+
+variable "enable_nat_gateway" {
+  description = "Whether to create a NAT gateway for private subnet internet access"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+```
+
+```hcl
+# locals.tf - Computed values and common tags
+locals {
+  common_tags = merge(var.tags, {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Module      = "terraform-aws-vpc"
+  })
+}
+```
+
+```hcl
+# main.tf - Resource definitions
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.vpc_name}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.vpc_name}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.vpc_name}-public-${var.availability_zones[count.index]}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(local.common_tags, {
+    Name = "${var.vpc_name}-private-${var.availability_zones[count.index]}"
+    Tier = "private"
+  })
+}
+
+resource "aws_eip" "nat" {
+  count = var.enable_nat_gateway ? 1 : 0
+
+  domain = "vpc"
+
+  tags = merge(local.common_tags, {
+    Name = "${var.vpc_name}-nat-eip"
+  })
+}
+
+resource "aws_nat_gateway" "main" {
+  count = var.enable_nat_gateway ? 1 : 0
+
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.vpc_name}-nat"
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.vpc_name}-public-rt"
+  })
+}
+
+resource "aws_route_table" "private" {
+  count = var.enable_nat_gateway ? 1 : 0
+
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[0].id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.vpc_name}-private-rt"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count = var.enable_nat_gateway ? length(var.private_subnet_cidrs) : 0
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[0].id
+}
+```
+
+```hcl
+# outputs.tf - All outputs with descriptions
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = aws_internet_gateway.main.id
+}
+
+output "nat_gateway_id" {
+  description = "The ID of the NAT Gateway (null if disabled)"
+  value       = var.enable_nat_gateway ? aws_nat_gateway.main[0].id : null
+}
+
+output "public_route_table_id" {
+  description = "The ID of the public route table"
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  description = "The ID of the private route table (null if NAT disabled)"
+  value       = var.enable_nat_gateway ? aws_route_table.private[0].id : null
+}
+
+output "nat_gateway_public_ip" {
+  description = "The public IP address of the NAT Gateway"
+  value       = var.enable_nat_gateway ? aws_eip.nat[0].public_ip : null
+}
+```
+
+### 2.3 Naming Changes Summary
+
+```text
+Before (inconsistent)        After (snake_case)
+─────────────────────────────────────────────────
+variable "cidr"              variable "vpc_cidr"
+variable "Name"              variable "vpc_name"
+variable "env"               variable "environment"
+variable "AZs"               variable "availability_zones"
+variable "publicSubnets"     variable "public_subnet_cidrs"
+variable "private_subnets"   variable "private_subnet_cidrs"
+variable "enable_nat"        variable "enable_nat_gateway"
+resource "aws_vpc" "vpc"     resource "aws_vpc" "main"
+resource "aws_igw" "igw"     resource "aws_internet_gateway" "main"
+output "public_subnets"      output "public_subnet_ids"
+output "private_subnets"     output "private_subnet_ids"
+```
+
+### Checkpoint 2
+
+```bash
+# Verify file structure
+ls -1 *.tf
+# Expected output:
+# locals.tf
+# main.tf
+# outputs.tf
+# variables.tf
+# versions.tf
+
+# Verify formatting
+terraform fmt -check .
+echo $?
+# Expected output: 0
+
+# Verify syntax validity
+terraform validate
+# Expected: Success! The configuration is valid.
+```
+
+---
+
+## Step 3: Add Variable Validation (5 min)
+
+Add validation blocks to `variables.tf` to catch misconfigurations before plan/apply.
+
+### 3.1 CIDR Validation
+
+```hcl
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC (e.g., 10.0.0.0/16)"
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "The vpc_cidr must be a valid CIDR block (e.g., 10.0.0.0/16)."
+  }
+
+  validation {
+    condition     = tonumber(split("/", var.vpc_cidr)[1]) >= 16 && tonumber(split("/", var.vpc_cidr)[1]) <= 24
+    error_message = "The vpc_cidr prefix length must be between /16 and /24."
+  }
+}
+```
+
+### 3.2 Environment Validation
+
+```hcl
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, production)"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "production", "sandbox"], var.environment)
+    error_message = "The environment must be one of: dev, staging, production, sandbox."
+  }
+}
+```
+
+### 3.3 Subnet and AZ Consistency Validation
+
+```hcl
+variable "availability_zones" {
+  description = "List of availability zones for subnet distribution"
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+
+  validation {
+    condition     = length(var.availability_zones) >= 2
+    error_message = "At least 2 availability zones are required for high availability."
+  }
+
+  validation {
+    condition     = length(var.availability_zones) == length(distinct(var.availability_zones))
+    error_message = "Availability zones must be unique (no duplicates)."
+  }
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets (one per AZ)"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) >= 1
+    error_message = "At least one public subnet CIDR is required."
+  }
+
+  validation {
+    condition     = alltrue([for cidr in var.public_subnet_cidrs : can(cidrhost(cidr, 0))])
+    error_message = "All public_subnet_cidrs must be valid CIDR blocks."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets (one per AZ)"
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.11.0/24"]
+
+  validation {
+    condition     = length(var.private_subnet_cidrs) >= 1
+    error_message = "At least one private subnet CIDR is required."
+  }
+
+  validation {
+    condition     = alltrue([for cidr in var.private_subnet_cidrs : can(cidrhost(cidr, 0))])
+    error_message = "All private_subnet_cidrs must be valid CIDR blocks."
+  }
+}
+```
+
+### 3.4 Name Validation
+
+```hcl
+variable "vpc_name" {
+  description = "Name prefix for all VPC resources"
+  type        = string
+
+  validation {
+    condition     = length(var.vpc_name) >= 3 && length(var.vpc_name) <= 28
+    error_message = "The vpc_name must be between 3 and 28 characters."
+  }
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.vpc_name))
+    error_message = "The vpc_name must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+```
+
+### 3.5 Tags Validation
+
+```hcl
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition     = alltrue([for k, v in var.tags : length(k) <= 128 && length(v) <= 256])
+    error_message = "Tag keys must be <= 128 characters and values <= 256 characters (AWS limits)."
+  }
+}
+```
+
+### Checkpoint 3
+
+```bash
+# Test that invalid inputs are caught
+cat > /tmp/test_invalid.tfvars <<'EOF'
+vpc_cidr    = "not-a-cidr"
+vpc_name    = "my-vpc"
+environment = "dev"
+EOF
+
+terraform plan -var-file=/tmp/test_invalid.tfvars 2>&1 | head -5
+# Expected: Error - The vpc_cidr must be a valid CIDR block
+
+cat > /tmp/test_valid.tfvars <<'EOF'
+vpc_cidr    = "10.0.0.0/16"
+vpc_name    = "my-vpc"
+environment = "dev"
+EOF
+
+terraform validate
+# Expected: Success! The configuration is valid.
+```
+
+---
+
+## Step 4: Write CONTRACT.md (10 min)
+
+Create a `CONTRACT.md` at the module root with numbered guarantees that map directly to tests.
+
+```markdown
+# Module Contract: terraform-aws-vpc
+
+> **Version**: 1.0.0
+> **Last Updated**: 2026-02-14
+> **Maintained by**: Platform Engineering Team
+> **Status**: Active
+
+## 1. Purpose
+
+This module creates a production-ready AWS VPC with public and private subnets,
+internet gateway, optional NAT gateway, and associated route tables. It provides
+network isolation and internet connectivity for application workloads running
+in AWS.
+
+## 2. Guarantees
+
+### Resource Guarantees
+
+- **G1**: Creates exactly 1 VPC with DNS hostnames and DNS support enabled
+- **G2**: Creates N public subnets distributed across at least 2 availability zones
+- **G3**: Creates N private subnets distributed across at least 2 availability zones
+- **G4**: Creates exactly 1 internet gateway attached to the VPC
+- **G5**: When `enable_nat_gateway = true`, creates exactly 1 NAT gateway in the first public subnet
+- **G6**: When `enable_nat_gateway = false`, creates no NAT gateway or EIP resources
+
+### Behavior Guarantees
+
+- **G7**: All resources are tagged with the common tag set (Environment, ManagedBy, Module)
+- **G8**: Public subnets have `map_public_ip_on_launch = true`
+- **G9**: Private subnets do NOT have `map_public_ip_on_launch` enabled
+- **G10**: Public route table routes 0.0.0.0/0 through the internet gateway
+- **G11**: Private route table (when NAT enabled) routes 0.0.0.0/0 through the NAT gateway
+- **G12**: Module is idempotent - running apply twice produces no changes on second run
+
+### Security Guarantees
+
+- **G13**: No security groups with 0.0.0.0/0 ingress are created by this module
+- **G14**: VPC flow logs are NOT enabled by default (consumer responsibility)
+
+## 3. Inputs
+
+| Variable               | Type         | Required | Default              | Validation                          |
+|------------------------|--------------|----------|----------------------|-------------------------------------|
+| `vpc_name`             | `string`     | Yes      | -                    | 3-28 chars, lowercase + hyphens     |
+| `vpc_cidr`             | `string`     | Yes      | -                    | Valid CIDR, /16 to /24              |
+| `environment`          | `string`     | No       | `"dev"`              | dev, staging, production, sandbox   |
+| `availability_zones`   | `list(string)` | No    | `["us-east-1a","us-east-1b"]` | Min 2, unique                |
+| `public_subnet_cidrs`  | `list(string)` | No    | `["10.0.1.0/24","10.0.2.0/24"]` | Valid CIDRs, min 1          |
+| `private_subnet_cidrs` | `list(string)` | No    | `["10.0.10.0/24","10.0.11.0/24"]` | Valid CIDRs, min 1        |
+| `enable_nat_gateway`   | `bool`       | No       | `true`               | -                                   |
+| `tags`                 | `map(string)` | No      | `{}`                 | Key <= 128, value <= 256 chars      |
+
+## 4. Outputs
+
+| Output                   | Type         | Description                                    |
+|--------------------------|--------------|------------------------------------------------|
+| `vpc_id`                 | `string`     | The ID of the created VPC                      |
+| `vpc_cidr_block`         | `string`     | The CIDR block of the VPC                      |
+| `public_subnet_ids`      | `list(string)` | List of public subnet IDs                   |
+| `private_subnet_ids`     | `list(string)` | List of private subnet IDs                  |
+| `internet_gateway_id`    | `string`     | The ID of the internet gateway                 |
+| `nat_gateway_id`         | `string`     | The NAT gateway ID (null if disabled)          |
+| `public_route_table_id`  | `string`     | The public route table ID                      |
+| `private_route_table_id` | `string`     | The private route table ID (null if disabled)  |
+| `nat_gateway_public_ip`  | `string`     | The public IP of the NAT gateway               |
+
+## 5. Platform Requirements
+
+| Requirement        | Version      | Notes                               |
+|--------------------|-------------|--------------------------------------|
+| Terraform          | >= 1.6      | Required for validation blocks       |
+| AWS Provider       | ~> 5.0      | Required for `domain` on EIP         |
+| AWS Account        | Any         | Must have VPC creation permissions   |
+| AWS Region         | Any         | Specified AZs must exist in region   |
+
+### Required IAM Permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVpc", "ec2:DeleteVpc", "ec2:DescribeVpcs", "ec2:ModifyVpcAttribute",
+        "ec2:CreateSubnet", "ec2:DeleteSubnet", "ec2:DescribeSubnets",
+        "ec2:CreateInternetGateway", "ec2:DeleteInternetGateway",
+        "ec2:AttachInternetGateway", "ec2:DetachInternetGateway",
+        "ec2:DescribeInternetGateways",
+        "ec2:AllocateAddress", "ec2:ReleaseAddress", "ec2:DescribeAddresses",
+        "ec2:CreateNatGateway", "ec2:DeleteNatGateway", "ec2:DescribeNatGateways",
+        "ec2:CreateRouteTable", "ec2:DeleteRouteTable", "ec2:DescribeRouteTables",
+        "ec2:CreateRoute", "ec2:DeleteRoute",
+        "ec2:AssociateRouteTable", "ec2:DisassociateRouteTable",
+        "ec2:CreateTags", "ec2:DeleteTags", "ec2:DescribeTags",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:ModifySubnetAttribute"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## 6. Side Effects and Cost Implications
+
+### Side Effects
+
+- Creates VPC, which counts against the regional VPC limit (default: 5)
+- Allocates Elastic IP when NAT gateway is enabled
+- Creates route table entries that affect network routing for all resources in the VPC
+
+### Cost Implications
+
+| Resource            | Estimated Cost (us-east-1)   | Condition              |
+|---------------------|------------------------------|------------------------|
+| VPC                 | Free                         | Always                 |
+| Subnets             | Free                         | Always                 |
+| Internet Gateway    | Free (data transfer charges) | Always                 |
+| NAT Gateway         | ~$32/month + data transfer   | `enable_nat_gateway`   |
+| Elastic IP          | Free (when attached to NAT)  | `enable_nat_gateway`   |
+
+**Warning**: NAT Gateway costs approximately $32/month. Set `enable_nat_gateway = false` for
+development environments where private subnet internet access is not required.
+
+## 7. Idempotency Contract
+
+- First `terraform apply`: Creates all resources
+- Second `terraform apply`: No changes (0 added, 0 changed, 0 destroyed)
+- `terraform destroy`: Removes all resources cleanly with no orphans
+
+## 8. Testing Requirements
+
+All guarantees must have corresponding test coverage:
+
+| Test File          | Guarantees Tested       | Type        |
+|--------------------|-------------------------|-------------|
+| `vpc_test.go`      | G1, G2, G3, G4, G7, G8 | Integration |
+| `vpc_test.go`      | G5, G6, G10, G11        | Integration |
+| `vpc_test.go`      | G12                     | Idempotency |
+
+## 9. Breaking Changes Policy
+
+- Minor versions (1.x.0): New variables with defaults, new outputs
+- Patch versions (1.0.x): Bug fixes, documentation updates
+- Major versions (x.0.0): Renamed variables, removed outputs, changed defaults
+- Deprecation notice: Minimum 1 minor version before removal
+
+## 10. Known Limitations
+
+- Single NAT gateway (not HA across AZs) - use `terraform-aws-vpc-ha` for multi-NAT
+- No IPv6 support
+- No VPC flow log configuration (consumer must add separately)
+- No VPC endpoints included
+- Subnet count must match AZ count
+
+## 11. Support
+
+- **Repository**: `github.com/your-org/terraform-aws-vpc`
+- **Issues**: GitHub Issues
+- **Slack**: `#platform-engineering`
+
+## 12. Usage Examples
+
+### Minimal
+
+```hcl
+module "vpc" {
+  source   = "github.com/your-org/terraform-aws-vpc?ref=v1.0.0"
+  vpc_name = "my-app"
+  vpc_cidr = "10.0.0.0/16"
+}
+```
+
+### Production
+
+```hcl
+module "vpc" {
+  source   = "github.com/your-org/terraform-aws-vpc?ref=v1.0.0"
+  vpc_name = "prod-platform"
+  vpc_cidr = "10.100.0.0/16"
+
+  environment        = "production"
+  availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c"]
+
+  public_subnet_cidrs  = ["10.100.1.0/24", "10.100.2.0/24", "10.100.3.0/24"]
+  private_subnet_cidrs = ["10.100.10.0/24", "10.100.11.0/24", "10.100.12.0/24"]
+
+  enable_nat_gateway = true
+
+  tags = {
+    Team        = "platform-engineering"
+    CostCenter  = "infrastructure"
+    Compliance  = "soc2"
+  }
+}
+```
+
+### Development (No NAT, Cost Savings)
+
+```hcl
+module "vpc" {
+  source   = "github.com/your-org/terraform-aws-vpc?ref=v1.0.0"
+  vpc_name = "dev-sandbox"
+  vpc_cidr = "10.200.0.0/16"
+
+  environment        = "dev"
+  enable_nat_gateway = false
+
+  tags = {
+    Team = "development"
+  }
+}
+```
+
+## 13. Test Mapping
+
+| Guarantee | Test Function                          | Test File      |
+|-----------|----------------------------------------|----------------|
+| G1        | `TestVpcCreation`                      | `vpc_test.go`  |
+| G2        | `TestPublicSubnetsAcrossAZs`          | `vpc_test.go`  |
+| G3        | `TestPrivateSubnetsAcrossAZs`         | `vpc_test.go`  |
+| G4        | `TestInternetGatewayAttached`         | `vpc_test.go`  |
+| G5        | `TestNatGatewayCreatedWhenEnabled`    | `vpc_test.go`  |
+| G6        | `TestNatGatewaySkippedWhenDisabled`   | `vpc_test.go`  |
+| G7        | `TestCommonTagsApplied`              | `vpc_test.go`  |
+| G8        | `TestPublicSubnetsAutoAssignIP`      | `vpc_test.go`  |
+| G9        | `TestPrivateSubnetsNoAutoAssignIP`   | `vpc_test.go`  |
+| G10       | `TestPublicRouteTableDefaultRoute`   | `vpc_test.go`  |
+| G11       | `TestPrivateRouteTableNatRoute`      | `vpc_test.go`  |
+| G12       | `TestIdempotency`                    | `vpc_test.go`  |
+| G13       | (Verified by code review)            | N/A            |
+| G14       | (Verified by code review)            | N/A            |
+
+### Checkpoint 4
+
+```bash
+# Verify CONTRACT.md exists and has all sections
+grep -c "^## " CONTRACT.md
+# Expected output: 13
+
+# Verify all guarantees are numbered
+grep -c "^\- \*\*G[0-9]" CONTRACT.md
+# Expected output: 14
+
+# Verify test mapping table is complete
+grep -c "G[0-9]" CONTRACT.md | head -1
+# Expected: multiple references per guarantee
+```
+
+---
+
+## Step 5: Add Metadata (3 min)
+
+Add `@module` metadata comments to each `.tf` file following the Dukes Engineering Style Guide metadata schema.
+
+### 5.1 Metadata for main.tf
+
+```hcl
+# @module terraform_aws_vpc
+# @description Production-ready AWS VPC module with public/private subnets,
+#   internet gateway, optional NAT gateway, and route tables
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2026-02-14
+# @status stable
+
+resource "aws_vpc" "main" {
+  # ... (existing resource definitions follow)
+```
+
+### 5.2 Metadata for variables.tf
+
+```hcl
+# @module terraform_aws_vpc_variables
+# @description Input variable definitions for the AWS VPC module
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2026-02-14
+# @status stable
+
+variable "vpc_name" {
+  # ... (existing variable definitions follow)
+```
+
+### 5.3 Metadata for outputs.tf
+
+```hcl
+# @module terraform_aws_vpc_outputs
+# @description Output definitions for the AWS VPC module
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2026-02-14
+# @status stable
+
+output "vpc_id" {
+  # ... (existing output definitions follow)
+```
+
+### 5.4 Metadata for versions.tf
+
+```hcl
+# @module terraform_aws_vpc_versions
+# @description Provider and Terraform version constraints for the AWS VPC module
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2026-02-14
+# @status stable
+
+terraform {
+  # ... (existing version constraints follow)
+```
+
+### 5.5 Metadata for locals.tf
+
+```hcl
+# @module terraform_aws_vpc_locals
+# @description Local values and computed tags for the AWS VPC module
+# @version 1.0.0
+# @author Tyler Dukes
+# @last_updated 2026-02-14
+# @status stable
+
+locals {
+  # ... (existing locals follow)
+```
+
+### Checkpoint 5
+
+```bash
+# Validate metadata across all .tf files
+python scripts/validate_metadata.py .
+
+# Expected output:
+# Validating metadata in .
+# ✅ main.tf: Valid metadata found
+# ✅ variables.tf: Valid metadata found
+# ✅ outputs.tf: Valid metadata found
+# ✅ versions.tf: Valid metadata found
+# ✅ locals.tf: Valid metadata found
+# Summary: 5 files validated, 0 errors
+```
+
+---
+
+## Step 6: Write Terratest Tests (10 min)
+
+Create a Go test file that validates each guarantee from the CONTRACT.md.
+
+### 6.1 Test Fixture
+
+```hcl
+# test/fixtures/main.tf - Test fixture that invokes the module
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "vpc" {
+  source = "../../"
+
+  vpc_name    = "test-vpc"
+  vpc_cidr    = "10.0.0.0/16"
+  environment = "dev"
+
+  availability_zones   = ["us-east-1a", "us-east-1b"]
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.10.0/24", "10.0.11.0/24"]
+
+  enable_nat_gateway = true
+
+  tags = {
+    TestRun = "terratest"
+  }
+}
+
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "vpc_cidr_block" {
+  value = module.vpc.vpc_cidr_block
+}
+
+output "public_subnet_ids" {
+  value = module.vpc.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  value = module.vpc.private_subnet_ids
+}
+
+output "internet_gateway_id" {
+  value = module.vpc.internet_gateway_id
+}
+
+output "nat_gateway_id" {
+  value = module.vpc.nat_gateway_id
+}
+
+output "public_route_table_id" {
+  value = module.vpc.public_route_table_id
+}
+
+output "private_route_table_id" {
+  value = module.vpc.private_route_table_id
+}
+
+output "nat_gateway_public_ip" {
+  value = module.vpc.nat_gateway_public_ip
+}
+```
+
+### 6.2 Test Fixture Without NAT
+
+```hcl
+# test/fixtures-no-nat/main.tf - Test fixture with NAT disabled
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "vpc" {
+  source = "../../"
+
+  vpc_name    = "test-no-nat"
+  vpc_cidr    = "10.1.0.0/16"
+  environment = "dev"
+
+  availability_zones   = ["us-east-1a", "us-east-1b"]
+  public_subnet_cidrs  = ["10.1.1.0/24", "10.1.2.0/24"]
+  private_subnet_cidrs = ["10.1.10.0/24", "10.1.11.0/24"]
+
+  enable_nat_gateway = false
+
+  tags = {
+    TestRun = "terratest"
+  }
+}
+
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "nat_gateway_id" {
+  value = module.vpc.nat_gateway_id
+}
+
+output "private_route_table_id" {
+  value = module.vpc.private_route_table_id
+}
+```
+
+### 6.3 Go Module Setup
+
+```bash
+# Initialize Go module for tests
+cd test
+go mod init github.com/your-org/terraform-aws-vpc/test
+
+# Add terratest dependency
+go get github.com/gruntwork-io/terratest/modules/terraform
+go get github.com/gruntwork-io/terratest/modules/aws
+go get github.com/stretchr/testify/assert
+go get github.com/stretchr/testify/require
+```
+
+```json
+// test/go.mod (generated, shown for reference)
+{
+  "module": "github.com/your-org/terraform-aws-vpc/test",
+  "go": "1.21",
+  "require": {
+    "github.com/gruntwork-io/terratest": "v0.47.2",
+    "github.com/stretchr/testify": "v1.9.0"
+  }
+}
+```
+
+### 6.4 Complete Test File
+
+```go
+// test/vpc_test.go
+package test
+
+import (
+ "fmt"
+ "testing"
+
+ "github.com/gruntwork-io/terratest/modules/aws"
+ "github.com/gruntwork-io/terratest/modules/terraform"
+ "github.com/stretchr/testify/assert"
+ "github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Test: G1 - Creates exactly 1 VPC with DNS hostnames and DNS support enabled
+// ============================================================================
+
+func TestVpcCreation(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+ terraform.InitAndApply(t, terraformOptions)
+
+ vpcID := terraform.Output(t, terraformOptions, "vpc_id")
+ require.NotEmpty(t, vpcID, "G1: VPC ID must not be empty")
+
+ vpc := aws.GetVpcById(t, vpcID, "us-east-1")
+ assert.True(t, vpc.EnableDnsHostnames, "G1: DNS hostnames must be enabled")
+ assert.True(t, vpc.EnableDnsSupport, "G1: DNS support must be enabled")
+
+ cidr := terraform.Output(t, terraformOptions, "vpc_cidr_block")
+ assert.Equal(t, "10.0.0.0/16", cidr, "G1: VPC CIDR must match input")
+}
+
+// ============================================================================
+// Test: G2 - Creates N public subnets across at least 2 AZs
+// ============================================================================
+
+func TestPublicSubnetsAcrossAZs(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+ terraform.InitAndApply(t, terraformOptions)
+
+ publicSubnetIDs := terraform.OutputList(t, terraformOptions, "public_subnet_ids")
+ assert.Equal(t, 2, len(publicSubnetIDs), "G2: Must create 2 public subnets")
+
+ // Verify subnets are in different AZs
+ azSet := make(map[string]bool)
+ for _, subnetID := range publicSubnetIDs {
+  subnet := aws.GetSubnetById(t, subnetID, "us-east-1")
+  azSet[subnet.AvailabilityZone] = true
+ }
+ assert.GreaterOrEqual(t, len(azSet), 2, "G2: Public subnets must span at least 2 AZs")
+}
+
+// ============================================================================
+// Test: G3 - Creates N private subnets across at least 2 AZs
+// ============================================================================
+
+func TestPrivateSubnetsAcrossAZs(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+ terraform.InitAndApply(t, terraformOptions)
+
+ privateSubnetIDs := terraform.OutputList(t, terraformOptions, "private_subnet_ids")
+ assert.Equal(t, 2, len(privateSubnetIDs), "G3: Must create 2 private subnets")
+
+ azSet := make(map[string]bool)
+ for _, subnetID := range privateSubnetIDs {
+  subnet := aws.GetSubnetById(t, subnetID, "us-east-1")
+  azSet[subnet.AvailabilityZone] = true
+ }
+ assert.GreaterOrEqual(t, len(azSet), 2, "G3: Private subnets must span at least 2 AZs")
+}
+
+// ============================================================================
+// Test: G4 - Creates exactly 1 internet gateway attached to the VPC
+// ============================================================================
+
+func TestInternetGatewayAttached(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+ terraform.InitAndApply(t, terraformOptions)
+
+ igwID := terraform.Output(t, terraformOptions, "internet_gateway_id")
+ require.NotEmpty(t, igwID, "G4: Internet gateway ID must not be empty")
+
+ vpcID := terraform.Output(t, terraformOptions, "vpc_id")
+ igws := aws.GetInternetGatewayById(t, igwID, "us-east-1")
+ assert.Equal(t, vpcID, igws.VpcId, "G4: Internet gateway must be attached to the VPC")
+}
+
+// ============================================================================
+// Test: G5 - NAT gateway created when enable_nat_gateway = true
+// ============================================================================
+
+func TestNatGatewayCreatedWhenEnabled(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+ terraform.InitAndApply(t, terraformOptions)
+
+ natGatewayID := terraform.Output(t, terraformOptions, "nat_gateway_id")
+ require.NotEmpty(t, natGatewayID, "G5: NAT gateway ID must not be empty when enabled")
+
+ publicIP := terraform.Output(t, terraformOptions, "nat_gateway_public_ip")
+ assert.NotEmpty(t, publicIP, "G5: NAT gateway must have a public IP")
+}
+
+// ============================================================================
+// Test: G6 - No NAT gateway when enable_nat_gateway = false
+// ============================================================================
+
+func TestNatGatewaySkippedWhenDisabled(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures-no-nat",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+ terraform.InitAndApply(t, terraformOptions)
+
+ natGatewayID := terraform.Output(t, terraformOptions, "nat_gateway_id")
+ assert.Empty(t, natGatewayID, "G6: NAT gateway must not be created when disabled")
+
+ privateRTID := terraform.Output(t, terraformOptions, "private_route_table_id")
+ assert.Empty(t, privateRTID, "G6: Private route table must not be created when NAT disabled")
+}
+
+// ============================================================================
+// Test: G7 - All resources tagged with common tag set
+// ============================================================================
+
+func TestCommonTagsApplied(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+ terraform.InitAndApply(t, terraformOptions)
+
+ vpcID := terraform.Output(t, terraformOptions, "vpc_id")
+ vpc := aws.GetVpcById(t, vpcID, "us-east-1")
+
+ assert.Equal(t, "dev", vpc.Tags["Environment"], "G7: Environment tag must be set")
+ assert.Equal(t, "terraform", vpc.Tags["ManagedBy"], "G7: ManagedBy tag must be set")
+ assert.Equal(t, "terraform-aws-vpc", vpc.Tags["Module"], "G7: Module tag must be set")
+ assert.Equal(t, "terratest", vpc.Tags["TestRun"], "G7: Custom tags must be merged")
+}
+
+// ============================================================================
+// Test: G8 - Public subnets auto-assign public IPs
+// ============================================================================
+
+func TestPublicSubnetsAutoAssignIP(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+ terraform.InitAndApply(t, terraformOptions)
+
+ publicSubnetIDs := terraform.OutputList(t, terraformOptions, "public_subnet_ids")
+ for _, subnetID := range publicSubnetIDs {
+  subnet := aws.GetSubnetById(t, subnetID, "us-east-1")
+  assert.True(t, subnet.MapPublicIpOnLaunch,
+   fmt.Sprintf("G8: Public subnet %s must auto-assign public IPs", subnetID))
+ }
+}
+
+// ============================================================================
+// Test: G12 - Idempotency - second apply produces no changes
+// ============================================================================
+
+func TestIdempotency(t *testing.T) {
+ t.Parallel()
+
+ terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+  TerraformDir: "./fixtures",
+ })
+
+ defer terraform.Destroy(t, terraformOptions)
+
+ // First apply
+ terraform.InitAndApply(t, terraformOptions)
+
+ // Second apply - should produce no changes
+ planOutput := terraform.Plan(t, terraformOptions)
+ assert.Contains(t, planOutput, "No changes",
+  "G12: Second apply must produce no changes (idempotency)")
+}
+```
+
+### 6.5 Test Helper for Parallel Test Suites
+
+```go
+// test/helpers_test.go
+package test
+
+import (
+ "fmt"
+ "math/rand"
+ "strings"
+ "time"
+)
+
+// uniqueID generates a unique suffix for test resource names to avoid conflicts
+// when running tests in parallel
+func uniqueID() string {
+ r := rand.New(rand.NewSource(time.Now().UnixNano()))
+ return fmt.Sprintf("%06d", r.Intn(999999))
+}
+
+// formatTestName creates a descriptive test name with guarantee reference
+func formatTestName(guarantee string, description string) string {
+ return fmt.Sprintf("[%s] %s", guarantee, description)
+}
+
+// assertTagsContain verifies that a tag map contains all expected key-value pairs
+func assertTagsContain(tags map[string]string, expected map[string]string) []string {
+ var missing []string
+ for k, v := range expected {
+  actual, ok := tags[k]
+  if !ok {
+   missing = append(missing, fmt.Sprintf("missing tag key: %s", k))
+  } else if actual != v {
+   missing = append(missing, fmt.Sprintf("tag %s: expected %q, got %q", k, v, actual))
+  }
+ }
+ return missing
+}
+
+// containsSubstring checks if any string in a slice contains the given substring
+func containsSubstring(slice []string, substr string) bool {
+ for _, s := range slice {
+  if strings.Contains(s, substr) {
+   return true
+  }
+ }
+ return false
+}
+```
+
+### Checkpoint 6
+
+```bash
+# Verify test file structure
+tree test/
+# Expected output:
+# test/
+# ├── fixtures/
+# │   └── main.tf
+# ├── fixtures-no-nat/
+# │   └── main.tf
+# ├── go.mod
+# ├── go.sum
+# ├── helpers_test.go
+# └── vpc_test.go
+
+# Verify Go compilation (does not run tests)
+cd test && go vet ./...
+# Expected: no errors
+
+# Run the tests (requires AWS credentials)
+cd test && go test -v -timeout 30m -run TestVpcCreation
+# Expected: PASS
+```
+
+---
+
+## Step 7: Set Up CI/CD (5 min)
+
+Create a GitHub Actions workflow that runs formatting checks, validation, planning, and tests on every pull request.
+
+### 7.1 CI Workflow
+
+```yaml
+# .github/workflows/ci.yml
+name: Terraform Module CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  TF_VERSION: "1.9.0"
+  GO_VERSION: "1.21"
+
+jobs:
+  # ──────────────────────────────────────────────────────────────
+  # Stage 1: Format and Validate
+  # ──────────────────────────────────────────────────────────────
+  format-and-validate:
+    name: Format & Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive -diff
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+  # ──────────────────────────────────────────────────────────────
+  # Stage 2: Security Scanning
+  # ──────────────────────────────────────────────────────────────
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tfsec
+        uses: aquasecurity/tfsec-action@v1.0.3
+        with:
+          working_directory: .
+          soft_fail: false
+
+      - name: Run checkov
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: .
+          framework: terraform
+          quiet: true
+
+  # ──────────────────────────────────────────────────────────────
+  # Stage 3: Terraform Plan
+  # ──────────────────────────────────────────────────────────────
+  plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    needs: [format-and-validate]
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        run: |
+          cd test/fixtures
+          terraform init
+
+      - name: Terraform Plan
+        run: |
+          cd test/fixtures
+          terraform plan -no-color -input=false
+        continue-on-error: true
+
+  # ──────────────────────────────────────────────────────────────
+  # Stage 4: Integration Tests
+  # ──────────────────────────────────────────────────────────────
+  test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: [format-and-validate, security]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: test/go.sum
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Run Terratest
+        working-directory: test
+        run: |
+          go mod download
+          go test -v -timeout 30m -count=1 ./...
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+
+  # ──────────────────────────────────────────────────────────────
+  # Stage 5: Documentation
+  # ──────────────────────────────────────────────────────────────
+  docs:
+    name: Generate Docs
+    runs-on: ubuntu-latest
+    needs: [format-and-validate]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Generate terraform-docs
+        uses: terraform-docs/gh-actions@v1
+        with:
+          working-dir: .
+          output-file: README.md
+          output-method: inject
+          git-push: "true"
+```
+
+### 7.2 Pre-commit Configuration
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-tf
+    rev: v1.96.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+        args:
+          - --args=--config=.terraform-docs.yml
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: detect-private-key
+```
+
+### 7.3 terraform-docs Configuration
+
+```yaml
+# .terraform-docs.yml
+formatter: markdown table
+
+header-from: doc-header.md
+
+sections:
+  show:
+    - header
+    - requirements
+    - providers
+    - inputs
+    - outputs
+    - resources
+
+content: ""
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: required
+```
+
+### Checkpoint 7
+
+```bash
+# Verify workflow file is valid YAML
+python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "Valid YAML"
+# Expected: Valid YAML
+
+# Verify pre-commit config
+pre-commit validate-config
+# Expected: no errors
+
+# Run pre-commit hooks locally
+pre-commit run --all-files
+# Expected: all checks pass
+
+# Dry-run the CI pipeline stages locally
+terraform fmt -check -recursive -diff
+terraform init -backend=false
+terraform validate
+# Expected: all pass
+```
+
+---
+
+## Step 8: Publish to Registry (2 min)
+
+### 8.1 Tag and Release
+
+```bash
+# Ensure you are on main with all changes committed
+git checkout main
+git pull origin main
+
+# Create a semantic version tag
+git tag -a v1.0.0 -m "feat: initial release of terraform-aws-vpc module
+
+Compliant with Dukes Engineering Style Guide:
+- Full CONTRACT.md with 14 guarantees
+- Terratest coverage for G1-G12
+- Variable validation for all inputs
+- Metadata tags on all .tf files
+- CI/CD pipeline with format, validate, security, and test stages"
+
+# Push the tag
+git push origin v1.0.0
+```
+
+### 8.2 Module Source References
+
+```hcl
+# Reference by Git tag (recommended)
+module "vpc" {
+  source = "git::https://github.com/your-org/terraform-aws-vpc.git?ref=v1.0.0"
+
+  vpc_name = "my-app"
+  vpc_cidr = "10.0.0.0/16"
+}
+```
+
+```hcl
+# Reference from Terraform Registry (if published)
+module "vpc" {
+  source  = "your-org/vpc/aws"
+  version = "1.0.0"
+
+  vpc_name = "my-app"
+  vpc_cidr = "10.0.0.0/16"
+}
+```
+
+### 8.3 Registry Naming Convention
+
+```text
+Terraform Registry Module Naming Convention
+════════════════════════════════════════════
+Repository name:   terraform-{provider}-{name}
+Example:           terraform-aws-vpc
+
+Required files:
+  ├── main.tf          (required)
+  ├── variables.tf     (required)
+  ├── outputs.tf       (required)
+  ├── versions.tf      (recommended)
+  ├── README.md        (required - auto-generated by terraform-docs)
+  ├── CONTRACT.md      (required by Dukes Style Guide)
+  ├── LICENSE           (required)
+  └── examples/
+      └── complete/
+          └── main.tf  (recommended)
+```
+
+---
+
+## Checkpoint: Final Verification
+
+Run through this checklist to confirm full compliance.
+
+```bash
+# 1. File structure
+echo "=== File Structure ==="
+find . -name "*.tf" -o -name "*.go" -o -name "*.md" -o -name "*.yml" | \
+  grep -v ".terraform" | sort
+
+# Expected:
+# ./.github/workflows/ci.yml
+# ./.pre-commit-config.yaml
+# ./.terraform-docs.yml
+# ./CONTRACT.md
+# ./locals.tf
+# ./main.tf
+# ./outputs.tf
+# ./test/fixtures-no-nat/main.tf
+# ./test/fixtures/main.tf
+# ./test/helpers_test.go
+# ./test/vpc_test.go
+# ./variables.tf
+# ./versions.tf
+```
+
+```bash
+# 2. Formatting
+echo "=== Formatting ==="
+terraform fmt -check -recursive .
+echo "Format check exit code: $?"
+# Expected: 0
+```
+
+```bash
+# 3. Validation
+echo "=== Validation ==="
+terraform init -backend=false
+terraform validate
+# Expected: Success! The configuration is valid.
+```
+
+```bash
+# 4. Metadata
+echo "=== Metadata ==="
+for f in main.tf variables.tf outputs.tf versions.tf locals.tf; do
+  if grep -q "@module" "$f"; then
+    echo "✅ $f has metadata"
+  else
+    echo "❌ $f missing metadata"
+  fi
+done
+# Expected: all ✅
+```
+
+```bash
+# 5. CONTRACT.md guarantees
+echo "=== CONTRACT.md ==="
+echo "Guarantees defined: $(grep -c '^\- \*\*G[0-9]' CONTRACT.md)"
+echo "Sections: $(grep -c '^## ' CONTRACT.md)"
+# Expected: 14 guarantees, 13 sections
+```
+
+```bash
+# 6. Test coverage
+echo "=== Test Coverage ==="
+grep -c "^func Test" test/vpc_test.go
+# Expected: 8 test functions
+
+echo "Guarantees covered by tests:"
+grep -oP 'G\d+' test/vpc_test.go | sort -u
+# Expected: G1, G2, G3, G4, G5, G6, G7, G8, G12
+```
+
+```bash
+# 7. Variable validation
+echo "=== Variable Validation ==="
+grep -c "validation {" variables.tf
+# Expected: 10 validation blocks
+```
+
+```text
+Final Compliance Checklist
+══════════════════════════
+[x] terraform fmt passes with no changes
+[x] All files follow standard layout (main.tf, variables.tf, outputs.tf, versions.tf, locals.tf)
+[x] All variables have descriptions and types
+[x] All variables have validation blocks where applicable
+[x] All outputs have descriptions
+[x] All resources use snake_case naming
+[x] All resources tagged with common tags via locals
+[x] CONTRACT.md exists with numbered guarantees
+[x] @module metadata on all .tf files
+[x] Terratest tests cover all testable guarantees
+[x] CI/CD workflow covers format, validate, security, test, and docs
+[x] Pre-commit hooks configured
+[x] Semantic version tag created
+[x] No hardcoded values (uses variables with validation)
+[x] Deprecated resource arguments updated (vpc = true -> domain = "vpc")
+```
+
+---
+
+## Common Troubleshooting
+
+### Problem: terraform fmt reports changes after manual editing
+
+```bash
+# Symptom
+terraform fmt -check .
+# Exit code 3, shows diff
+
+# Cause: Editor inserted tabs instead of spaces, or misaligned = signs
+
+# Solution: Run terraform fmt to auto-fix
+terraform fmt -recursive .
+
+# Prevention: Configure your editor
+# VS Code: settings.json
+# "editor.formatOnSave": true,
+# "[terraform]": { "editor.defaultFormatter": "hashicorp.terraform" }
+```
+
+### Problem: terraform validate fails with provider errors
+
+```bash
+# Symptom
+terraform validate
+# Error: Missing required provider
+
+# Cause: Running validate without init, or wrong provider version
+
+# Solution: Initialize without backend first
+terraform init -backend=false
+terraform validate
+
+# If provider version conflict:
+rm -rf .terraform .terraform.lock.hcl
+terraform init -backend=false
+```
+
+### Problem: Terratest times out during apply
+
+```bash
+# Symptom
+go test -v -timeout 10m ./...
+# panic: test timed out after 10m
+
+# Cause: NAT gateway creation takes 2-5 minutes, total test > 10 min
+
+# Solution: Increase timeout
+go test -v -timeout 30m ./...
+
+# For CI, set in workflow:
+# run: go test -v -timeout 30m -count=1 ./...
+```
+
+### Problem: Validation blocks reject valid input
+
+```hcl
+# Symptom
+# Error: The vpc_cidr prefix length must be between /16 and /24.
+# Input: "10.0.0.0/8"
+
+# Cause: Validation rule restricts to /16-/24 range for safety
+
+# Solution: If /8 is intentional, update the validation rule in variables.tf
+variable "vpc_cidr" {
+  # ...
+  validation {
+    condition     = tonumber(split("/", var.vpc_cidr)[1]) >= 8 && tonumber(split("/", var.vpc_cidr)[1]) <= 24
+    error_message = "The vpc_cidr prefix length must be between /8 and /24."
+  }
+}
+```
+
+### Problem: Tests fail with "no default VPC" or credential errors
+
+```bash
+# Symptom
+TestVpcCreation 2026/02/14 10:00:00 retry.go:91:
+# error: NoCredentialProviders
+
+# Cause: AWS credentials not configured for test environment
+
+# Solution: Set AWS credentials
+export AWS_ACCESS_KEY_ID="your-key"
+export AWS_SECRET_ACCESS_KEY="your-secret"
+export AWS_DEFAULT_REGION="us-east-1"
+
+# Or use AWS SSO
+aws sso login --profile your-profile
+export AWS_PROFILE="your-profile"
+
+# Verify credentials
+aws sts get-caller-identity
+```
+
+### Problem: Pre-commit terraform_docs hook fails
+
+```bash
+# Symptom
+terraform_docs..........................................................Failed
+# Error: Could not find .terraform-docs.yml
+
+# Cause: Missing terraform-docs config file
+
+# Solution: Create .terraform-docs.yml at repository root
+# (See Step 7.3 for the configuration)
+
+# Verify
+terraform-docs markdown table --config .terraform-docs.yml .
+```
+
+### Problem: CONTRACT.md guarantee numbers are not sequential
+
+```bash
+# Symptom: G1, G2, G4, G5 (missing G3)
+
+# Cause: Guarantee was removed without renumbering
+
+# Solution: Always renumber sequentially, and update test mapping
+# Use grep to find all references:
+grep -rn "G3" . --include="*.go" --include="*.md"
+# Update all references to maintain sequential numbering
+```
+
+---
+
+## Next Steps
+
+After completing this tutorial, you have a fully compliant Terraform module. Here are recommended next steps:
+
+```text
+Recommended Path
+════════════════
+1. Add VPC Flow Logs           → Extend the module with optional flow log support
+2. Multi-NAT HA                → Create a high-availability variant with per-AZ NAT gateways
+3. VPC Endpoints               → Add optional S3 and DynamoDB gateway endpoints
+4. Tutorial 3: Full-Stack App  → Build on this VPC module in a complete application stack
+5. Team Onboarding             → Use Tutorial 4 to onboard your team to the style guide
+```
+
+```text
+Related Style Guide References
+══════════════════════════════
+- Terraform Style Guide        → docs/02_language_guides/terraform.md
+- CONTRACT.md Template         → docs/04_templates/contract_template.md
+- IaC Testing Standards        → docs/05_ci_cd/iac_testing.md
+- Metadata Schema              → docs/03_metadata_schema/
+- CI/CD Standards              → docs/05_ci_cd/
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,5 +185,12 @@ nav:
       - Integration Guide: 07_integration/integration_prompt.md
       - AI Code Review: 07_integration/ai_code_review.md
       - CLI Tool: 07_integration/cli_tool.md
+  - Tutorials:
+      - Overview: 12_tutorials/index.md
+      - "1: Zero to Validated Python Project": 12_tutorials/python_project.md
+      - "2: Migrating Existing Terraform Module": 12_tutorials/terraform_migration.md
+      - "3: Full-Stack App with Multiple Languages": 12_tutorials/fullstack_app.md
+      - "4: Team Onboarding": 12_tutorials/team_onboarding.md
+      - "5: From Manual to Automated": 12_tutorials/manual_to_automated.md
   - Glossary: glossary.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

- Adds 5 comprehensive, step-by-step tutorials in `docs/12_tutorials/`
- Tutorial 1: **Zero to Validated Python Project** (30 min) - Flask API from scratch with full validation
- Tutorial 2: **Migrating Existing Terraform Module** (45 min) - Legacy code to CONTRACT.md + Terratest
- Tutorial 3: **Full-Stack App with Multiple Languages** (60 min) - Python + TypeScript + Terraform monorepo
- Tutorial 4: **Team Onboarding** (20 min) - Get a team up and running with the style guide
- Tutorial 5: **From Manual to Automated** (40 min) - Progressive automation pipeline setup
- Includes index page with tutorial map, learning paths, and prerequisites
- Updates `mkdocs.yml` navigation with new Tutorials section

Closes #194

## Test plan

- [x] All pre-commit hooks pass (markdownlint, yamllint, trailing whitespace, etc.)
- [x] `mkdocs build --strict` passes with no new warnings
- [x] All code blocks have language tags
- [x] YAML frontmatter present on all tutorial files
- [ ] Verify docs render correctly on GitHub Pages after merge
- [ ] Verify navigation links work in deployed documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)