### PR TITLE
feat(docs): add dark mode toggle, print styles, and copy code buttons

### DIFF
--- a/docs/stylesheets/print.css
+++ b/docs/stylesheets/print.css
@@ -1,0 +1,52 @@
+@media print {
+  /* Hide navigation, search, footer, and other non-content elements */
+  .md-header,
+  .md-tabs,
+  .md-sidebar,
+  .md-footer,
+  .md-search,
+  .md-top,
+  .md-source,
+  .md-clipboard {
+    display: none !important;
+  }
+
+  /* Full-width content area */
+  .md-content {
+    margin: 0 !important;
+    max-width: 100% !important;
+  }
+
+  .md-main__inner {
+    max-width: 100% !important;
+  }
+
+  /* Prevent code blocks from breaking across pages */
+  pre,
+  code {
+    page-break-inside: avoid;
+  }
+
+  /* Keep headings with their content */
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+
+  /* Prevent tables from breaking across pages when possible */
+  table {
+    page-break-inside: avoid;
+  }
+
+  /* Show link URLs in print */
+  .md-content a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  /* Don't show URLs for anchor links or javascript links */
+  .md-content a[href^="#"]::after,
+  .md-content a[href^="javascript"]::after {
+    content: "";
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ theme:
   features:
     - navigation.tabs
     - content.code.annotate
+    - content.code.copy
     - search.highlight
     - search.share
     - search.suggest
@@ -18,6 +19,15 @@ theme:
     - scheme: default
       primary: indigo
       accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
 plugins:
   - search:
       separator: '[\s\-\.]+'
@@ -25,6 +35,8 @@ plugins:
   - mike:
       alias_type: symlink
       canonical_version: latest
+extra_css:
+  - stylesheets/print.css
 extra:
   version:
     provider: mike


### PR DESCRIPTION
## Summary
- Adds dark/light mode toggle using MkDocs Material's built-in palette switcher (persists user preference via localStorage)
- Enables copy-to-clipboard buttons on all code blocks via `content.code.copy` feature
- Adds print-friendly stylesheet that hides navigation/sidebar, prevents code block page breaks, and displays link URLs

## Changes
- **`mkdocs.yml`**: Added `content.code.copy` feature, palette toggle with `default`/`slate` schemes, and `extra_css` reference
- **`docs/stylesheets/print.css`**: New print media query stylesheet

Closes #292

## Test plan
- [ ] Verify dark mode toggle appears in header and switches themes
- [ ] Verify theme preference persists across page loads
- [ ] Verify copy button appears on code blocks and copies content
- [ ] Verify print preview hides nav/sidebar and keeps code blocks intact
- [ ] Verify `mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)