### PR TITLE
feat(docs): add quick search shortcut and sticky TOC with highlighting

### DIFF
--- a/docs/javascripts/shortcuts.js
+++ b/docs/javascripts/shortcuts.js
@@ -1,0 +1,10 @@
+document.addEventListener("keydown", function (e) {
+  if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+    e.preventDefault();
+    var search = document.querySelector(".md-search__input");
+    if (search) {
+      search.focus();
+      search.select();
+    }
+  }
+});

--- a/docs/stylesheets/toc.css
+++ b/docs/stylesheets/toc.css
@@ -1,0 +1,6 @@
+.md-nav__link--active {
+  color: var(--md-accent-fg-color) !important;
+  font-weight: 700;
+  border-left: 2px solid var(--md-accent-fg-color);
+  padding-left: 0.4rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,8 @@ theme:
   language: en
   features:
     - navigation.tabs
+    - navigation.top
+    - toc.follow
     - content.code.annotate
     - content.code.copy
     - search.highlight
@@ -37,6 +39,9 @@ plugins:
       canonical_version: latest
 extra_css:
   - stylesheets/print.css
+  - stylesheets/toc.css
+extra_javascript:
+  - javascripts/shortcuts.js
 extra:
   version:
     provider: mike


### PR DESCRIPTION
## Summary
- Adds **Cmd+K / Ctrl+K** keyboard shortcut to focus the search input (`docs/javascripts/shortcuts.js`)
- Enables **`toc.follow`** for scroll-spy TOC that auto-scrolls to the active heading
- Enables **`navigation.top`** for a back-to-top button
- Adds **enhanced TOC active link styling** with accent color and left border (`docs/stylesheets/toc.css`)

Closes #293

## Test plan
- [ ] Run `mkdocs serve` and verify Cmd+K / Ctrl+K opens/focuses search
- [ ] Scroll through a long page and verify TOC highlights the current section
- [ ] Verify back-to-top button appears when scrolling down
- [ ] Verify `mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)