### PR TITLE
feat(docs): add related pages suggestions and bookmark/favorites system

### DIFF
--- a/docs/javascripts/bookmarks.js
+++ b/docs/javascripts/bookmarks.js
@@ -1,0 +1,345 @@
+/**
+ * Bookmarks - LocalStorage-based page bookmarking system
+ *
+ * Provides a star icon on each page to bookmark it and a dropdown in the
+ * header to view/manage saved bookmarks plus recently viewed pages.
+ */
+(function () {
+  "use strict";
+
+  var STORAGE_KEY = "dsg-bookmarks";
+  var RECENT_KEY = "dsg-recent-pages";
+  var MAX_RECENT = 10;
+
+  // --- Storage helpers ---
+
+  function getBookmarks() {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveBookmarks(bookmarks) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(bookmarks));
+  }
+
+  function isBookmarked(url) {
+    return getBookmarks().some(function (b) {
+      return b.url === url;
+    });
+  }
+
+  function addBookmark(url, title) {
+    var bookmarks = getBookmarks();
+    if (
+      bookmarks.some(function (b) {
+        return b.url === url;
+      })
+    ) {
+      return;
+    }
+    bookmarks.unshift({ url: url, title: title, timestamp: Date.now() });
+    saveBookmarks(bookmarks);
+  }
+
+  function removeBookmark(url) {
+    var bookmarks = getBookmarks().filter(function (b) {
+      return b.url !== url;
+    });
+    saveBookmarks(bookmarks);
+  }
+
+  function getRecentPages() {
+    try {
+      return JSON.parse(localStorage.getItem(RECENT_KEY) || "[]");
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function trackPageView(url, title) {
+    var recent = getRecentPages().filter(function (r) {
+      return r.url !== url;
+    });
+    recent.unshift({ url: url, title: title, timestamp: Date.now() });
+    if (recent.length > MAX_RECENT) {
+      recent = recent.slice(0, MAX_RECENT);
+    }
+    localStorage.setItem(RECENT_KEY, JSON.stringify(recent));
+  }
+
+  // --- URL helpers ---
+
+  function getCurrentUrl() {
+    return window.location.pathname;
+  }
+
+  function getPageTitle() {
+    var h1 = document.querySelector("article h1");
+    if (h1) return h1.textContent.replace(/¶$/, "").trim();
+    return document.title.split(" - ")[0].trim();
+  }
+
+  // --- SVG icons ---
+
+  var STAR_OUTLINE =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">' +
+    '<path fill="none" stroke="currentColor" stroke-width="1.5" ' +
+    'd="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01z"/>' +
+    "</svg>";
+
+  var STAR_FILLED =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">' +
+    '<path fill="currentColor" ' +
+    'd="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01z"/>' +
+    "</svg>";
+
+  var BOOKMARK_ICON =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">' +
+    '<path fill="currentColor" d="M17 3H7c-1.1 0-2 .9-2 2v16l7-3 7 3V5c0-1.1-.9-2-2-2z"/>' +
+    "</svg>";
+
+  // --- Bookmark star on page ---
+
+  function createStarButton() {
+    var url = getCurrentUrl();
+    var btn = document.createElement("button");
+    btn.className = "bookmark-star";
+    btn.setAttribute("aria-label", "Bookmark this page");
+    btn.setAttribute("title", "Bookmark this page");
+    btn.innerHTML = isBookmarked(url) ? STAR_FILLED : STAR_OUTLINE;
+
+    if (isBookmarked(url)) {
+      btn.classList.add("bookmark-star--active");
+    }
+
+    btn.addEventListener("click", function () {
+      var pageUrl = getCurrentUrl();
+      var title = getPageTitle();
+      if (isBookmarked(pageUrl)) {
+        removeBookmark(pageUrl);
+        btn.innerHTML = STAR_OUTLINE;
+        btn.classList.remove("bookmark-star--active");
+        btn.setAttribute("title", "Bookmark this page");
+      } else {
+        addBookmark(pageUrl, title);
+        btn.innerHTML = STAR_FILLED;
+        btn.classList.add("bookmark-star--active");
+        btn.setAttribute("title", "Remove bookmark");
+      }
+      updateDropdownContent();
+    });
+
+    return btn;
+  }
+
+  function insertStarButton() {
+    // Remove any existing star
+    var existing = document.querySelector(".bookmark-star");
+    if (existing) existing.remove();
+
+    var h1 = document.querySelector("article h1");
+    if (h1) {
+      var star = createStarButton();
+      h1.appendChild(star);
+    }
+  }
+
+  // --- Header dropdown ---
+
+  var dropdownEl = null;
+
+  function createHeaderButton() {
+    // Don't duplicate
+    if (document.querySelector(".bookmarks-toggle")) return;
+
+    var header = document.querySelector(".md-header__inner");
+    if (!header) return;
+
+    var container = document.createElement("div");
+    container.className = "bookmarks-container";
+
+    var toggle = document.createElement("button");
+    toggle.className = "bookmarks-toggle md-icon";
+    toggle.setAttribute("aria-label", "Bookmarks");
+    toggle.setAttribute("title", "Bookmarks");
+    toggle.innerHTML = BOOKMARK_ICON;
+
+    var count = getBookmarks().length;
+    if (count > 0) {
+      var badge = document.createElement("span");
+      badge.className = "bookmarks-badge";
+      badge.textContent = count;
+      toggle.appendChild(badge);
+    }
+
+    dropdownEl = document.createElement("div");
+    dropdownEl.className = "bookmarks-dropdown";
+    dropdownEl.setAttribute("role", "menu");
+    updateDropdownContent();
+
+    toggle.addEventListener("click", function (e) {
+      e.stopPropagation();
+      dropdownEl.classList.toggle("bookmarks-dropdown--open");
+      updateDropdownContent();
+    });
+
+    // Close on outside click
+    document.addEventListener("click", function (e) {
+      if (!container.contains(e.target)) {
+        dropdownEl.classList.remove("bookmarks-dropdown--open");
+      }
+    });
+
+    container.appendChild(toggle);
+    container.appendChild(dropdownEl);
+
+    // Insert before the search or repo icon
+    var searchBtn =
+      header.querySelector(".md-search") ||
+      header.querySelector(".md-header__button");
+    if (searchBtn) {
+      header.insertBefore(container, searchBtn);
+    } else {
+      header.appendChild(container);
+    }
+  }
+
+  function updateDropdownContent() {
+    if (!dropdownEl) return;
+
+    var bookmarks = getBookmarks();
+    var recent = getRecentPages();
+    var html = "";
+
+    // Bookmarks section
+    html += '<div class="bookmarks-dropdown__section">';
+    html +=
+      '<h3 class="bookmarks-dropdown__heading">Bookmarks</h3>';
+    if (bookmarks.length === 0) {
+      html +=
+        '<p class="bookmarks-dropdown__empty">No bookmarks yet. Click the star on any page to save it.</p>';
+    } else {
+      html += '<ul class="bookmarks-dropdown__list">';
+      for (var i = 0; i < bookmarks.length; i++) {
+        html += '<li class="bookmarks-dropdown__item">';
+        html +=
+          '<a href="' +
+          escapeHtml(bookmarks[i].url) +
+          '" class="bookmarks-dropdown__link">' +
+          escapeHtml(bookmarks[i].title) +
+          "</a>";
+        html +=
+          '<button class="bookmarks-dropdown__remove" data-url="' +
+          escapeHtml(bookmarks[i].url) +
+          '" aria-label="Remove bookmark" title="Remove">&times;</button>';
+        html += "</li>";
+      }
+      html += "</ul>";
+    }
+    html += "</div>";
+
+    // Recently viewed section
+    html += '<div class="bookmarks-dropdown__section">';
+    html +=
+      '<h3 class="bookmarks-dropdown__heading">Recently Viewed</h3>';
+    if (recent.length === 0) {
+      html +=
+        '<p class="bookmarks-dropdown__empty">No recent pages.</p>';
+    } else {
+      html += '<ul class="bookmarks-dropdown__list">';
+      var shown = 0;
+      for (var j = 0; j < recent.length && shown < 5; j++) {
+        // Skip current page
+        if (recent[j].url === getCurrentUrl()) continue;
+        html += '<li class="bookmarks-dropdown__item">';
+        html +=
+          '<a href="' +
+          escapeHtml(recent[j].url) +
+          '" class="bookmarks-dropdown__link">' +
+          escapeHtml(recent[j].title) +
+          "</a>";
+        html += "</li>";
+        shown++;
+      }
+      html += "</ul>";
+    }
+    html += "</div>";
+
+    dropdownEl.innerHTML = html;
+
+    // Attach remove handlers
+    var removeBtns = dropdownEl.querySelectorAll(".bookmarks-dropdown__remove");
+    for (var k = 0; k < removeBtns.length; k++) {
+      removeBtns[k].addEventListener("click", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var url = this.getAttribute("data-url");
+        removeBookmark(url);
+        updateDropdownContent();
+        updateBadge();
+        // Update star if on same page
+        if (url === getCurrentUrl()) {
+          var star = document.querySelector(".bookmark-star");
+          if (star) {
+            star.innerHTML = STAR_OUTLINE;
+            star.classList.remove("bookmark-star--active");
+          }
+        }
+      });
+    }
+  }
+
+  function updateBadge() {
+    var badge = document.querySelector(".bookmarks-badge");
+    var count = getBookmarks().length;
+    if (badge) {
+      if (count > 0) {
+        badge.textContent = count;
+        badge.style.display = "";
+      } else {
+        badge.style.display = "none";
+      }
+    } else if (count > 0) {
+      var toggle = document.querySelector(".bookmarks-toggle");
+      if (toggle) {
+        var newBadge = document.createElement("span");
+        newBadge.className = "bookmarks-badge";
+        newBadge.textContent = count;
+        toggle.appendChild(newBadge);
+      }
+    }
+  }
+
+  function escapeHtml(str) {
+    var div = document.createElement("div");
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
+  // --- Initialize ---
+
+  function init() {
+    var url = getCurrentUrl();
+    var title = getPageTitle();
+    trackPageView(url, title);
+    insertStarButton();
+    createHeaderButton();
+    updateBadge();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  // Re-run on MkDocs Material instant navigation
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(function () {
+      init();
+    });
+  }
+})();

--- a/docs/javascripts/related-pages.js
+++ b/docs/javascripts/related-pages.js
@@ -1,0 +1,196 @@
+/**
+ * Related Pages - Auto-generated "See Also" suggestions based on tag similarity
+ *
+ * Fetches page-index.json (generated at build time) and displays related pages
+ * at the bottom of each documentation page.
+ */
+(function () {
+  "use strict";
+
+  var MAX_RELATED = 5;
+  var MIN_SIMILARITY = 1;
+
+  function getCurrentPageUrl() {
+    var path = window.location.pathname;
+    var base = document.querySelector('meta[name="base_url"]');
+    if (base) {
+      path = path.replace(base.getAttribute("content"), "");
+    }
+    // Normalize: remove leading slash, trailing index.html
+    path = path.replace(/^\//, "").replace(/index\.html$/, "");
+    // Remove site prefix if present (e.g., /coding-style-guide/)
+    var link = document.querySelector('link[rel="canonical"]');
+    if (link) {
+      try {
+        var canonical = new URL(link.getAttribute("href"));
+        var siteBase = canonical.pathname.split("/").slice(0, -2).join("/");
+        if (siteBase && path.indexOf(siteBase.replace(/^\//, "")) === 0) {
+          path = path.replace(siteBase.replace(/^\//, "") + "/", "");
+        }
+      } catch (e) {
+        // ignore
+      }
+    }
+    return path;
+  }
+
+  function calculateSimilarity(tagsA, tagsB) {
+    var shared = 0;
+    for (var i = 0; i < tagsA.length; i++) {
+      if (tagsB.indexOf(tagsA[i]) !== -1) {
+        shared++;
+      }
+    }
+    return shared;
+  }
+
+  function findRelatedPages(currentUrl, pages) {
+    var currentPage = null;
+    for (var i = 0; i < pages.length; i++) {
+      if (pages[i].url === currentUrl) {
+        currentPage = pages[i];
+        break;
+      }
+    }
+    if (!currentPage || !currentPage.tags || currentPage.tags.length === 0) {
+      return [];
+    }
+
+    var scored = [];
+    for (var j = 0; j < pages.length; j++) {
+      var page = pages[j];
+      if (page.url === currentUrl) continue;
+      if (!page.tags || page.tags.length === 0) continue;
+
+      var tagScore = calculateSimilarity(currentPage.tags, page.tags);
+      var categoryBonus = page.category === currentPage.category ? 1 : 0;
+      var total = tagScore + categoryBonus;
+
+      if (total >= MIN_SIMILARITY) {
+        scored.push({ page: page, score: total });
+      }
+    }
+
+    scored.sort(function (a, b) {
+      return b.score - a.score;
+    });
+
+    return scored.slice(0, MAX_RELATED).map(function (item) {
+      return item.page;
+    });
+  }
+
+  function resolvePageHref(pageUrl) {
+    // Build relative URL from site root
+    var base =
+      document.querySelector('base[href]') ||
+      document.querySelector('meta[name="base_url"]');
+    var prefix = "";
+    if (base) {
+      prefix = base.getAttribute("href") || base.getAttribute("content") || "";
+    }
+    if (prefix && prefix.charAt(prefix.length - 1) !== "/") {
+      prefix += "/";
+    }
+    return prefix + pageUrl;
+  }
+
+  function renderRelatedPages(related) {
+    if (related.length === 0) return;
+
+    var article = document.querySelector("article.md-content__inner");
+    if (!article) return;
+
+    var section = document.createElement("div");
+    section.className = "related-pages";
+    section.setAttribute("role", "complementary");
+    section.setAttribute("aria-label", "Related pages");
+
+    var heading = document.createElement("h2");
+    heading.className = "related-pages__title";
+    heading.textContent = "See Also";
+
+    var list = document.createElement("ul");
+    list.className = "related-pages__list";
+
+    for (var i = 0; i < related.length; i++) {
+      var page = related[i];
+      var li = document.createElement("li");
+      li.className = "related-pages__item";
+
+      var link = document.createElement("a");
+      link.className = "related-pages__link";
+      link.href = resolvePageHref(page.url);
+      link.textContent = page.title;
+
+      if (page.category) {
+        var badge = document.createElement("span");
+        badge.className = "related-pages__badge";
+        badge.textContent = page.category;
+        li.appendChild(link);
+        li.appendChild(badge);
+      } else {
+        li.appendChild(link);
+      }
+
+      list.appendChild(li);
+    }
+
+    section.appendChild(heading);
+    section.appendChild(list);
+
+    // Insert before footer/last-updated or at end of article
+    var footer = article.querySelector(".md-source-file");
+    if (footer) {
+      article.insertBefore(section, footer);
+    } else {
+      article.appendChild(section);
+    }
+  }
+
+  function init() {
+    // Determine base URL for fetching page-index.json
+    var base =
+      document.querySelector('base[href]') ||
+      document.querySelector('meta[name="base_url"]');
+    var prefix = "";
+    if (base) {
+      prefix = base.getAttribute("href") || base.getAttribute("content") || "";
+    }
+    if (prefix && prefix.charAt(prefix.length - 1) !== "/") {
+      prefix += "/";
+    }
+
+    var indexUrl = prefix + "page-index.json";
+
+    fetch(indexUrl)
+      .then(function (response) {
+        if (!response.ok) return null;
+        return response.json();
+      })
+      .then(function (pages) {
+        if (!pages) return;
+
+        var currentUrl = getCurrentPageUrl();
+        var related = findRelatedPages(currentUrl, pages);
+        renderRelatedPages(related);
+      })
+      .catch(function () {
+        // Silently fail - related pages are non-critical
+      });
+  }
+
+  // Run after DOM is ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  // Re-run on MkDocs Material instant navigation
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(function () {
+      init();
+    });
+  }
+})();

--- a/docs/stylesheets/features.css
+++ b/docs/stylesheets/features.css
@@ -1,0 +1,238 @@
+/* ==========================================================================
+   Related Pages - "See Also" section
+   ========================================================================== */
+
+.related-pages {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.related-pages__title {
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.related-pages__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.5rem;
+}
+
+.related-pages__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  background: var(--md-code-bg-color);
+  transition: background 0.2s;
+}
+
+.related-pages__item:hover {
+  background: var(--md-accent-fg-color--transparent);
+}
+
+.related-pages__link {
+  color: var(--md-typeset-a-color);
+  text-decoration: none;
+  font-weight: 500;
+  flex: 1;
+}
+
+.related-pages__link:hover {
+  text-decoration: underline;
+}
+
+.related-pages__badge {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  background: var(--md-accent-fg-color--transparent);
+  color: var(--md-accent-fg-color);
+  white-space: nowrap;
+}
+
+/* ==========================================================================
+   Bookmark Star (on page headings)
+   ========================================================================== */
+
+.bookmark-star {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--md-default-fg-color--light);
+  padding: 0.15rem;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+  border-radius: 3px;
+  transition: color 0.2s, transform 0.15s;
+  line-height: 1;
+}
+
+.bookmark-star:hover {
+  color: var(--md-accent-fg-color);
+  transform: scale(1.15);
+}
+
+.bookmark-star--active {
+  color: #f5a623;
+}
+
+.bookmark-star--active:hover {
+  color: #e09100;
+}
+
+/* ==========================================================================
+   Bookmarks Header Button & Dropdown
+   ========================================================================== */
+
+.bookmarks-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-right: 0.25rem;
+}
+
+.bookmarks-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--md-primary-bg-color);
+  padding: 0.4rem;
+  border-radius: 4px;
+  position: relative;
+  transition: opacity 0.2s;
+}
+
+.bookmarks-toggle:hover {
+  opacity: 0.8;
+}
+
+.bookmarks-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: var(--md-accent-fg-color);
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  line-height: 16px;
+  text-align: center;
+  border-radius: 8px;
+  padding: 0 3px;
+}
+
+.bookmarks-dropdown {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 99;
+  min-width: 280px;
+  max-width: 360px;
+  max-height: 70vh;
+  overflow-y: auto;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  margin-top: 0.25rem;
+}
+
+.bookmarks-dropdown--open {
+  display: block;
+}
+
+.bookmarks-dropdown__section {
+  padding: 0.75rem 1rem;
+}
+
+.bookmarks-dropdown__section + .bookmarks-dropdown__section {
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.bookmarks-dropdown__heading {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--md-default-fg-color--light);
+  margin: 0 0 0.5rem;
+}
+
+.bookmarks-dropdown__empty {
+  font-size: 0.8rem;
+  color: var(--md-default-fg-color--lighter);
+  margin: 0;
+  font-style: italic;
+}
+
+.bookmarks-dropdown__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.bookmarks-dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.bookmarks-dropdown__link {
+  flex: 1;
+  display: block;
+  padding: 0.35rem 0;
+  color: var(--md-typeset-a-color);
+  text-decoration: none;
+  font-size: 0.85rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bookmarks-dropdown__link:hover {
+  text-decoration: underline;
+}
+
+.bookmarks-dropdown__remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--md-default-fg-color--lighter);
+  font-size: 1.1rem;
+  padding: 0.2rem 0.4rem;
+  line-height: 1;
+  border-radius: 3px;
+  transition: color 0.2s, background 0.2s;
+}
+
+.bookmarks-dropdown__remove:hover {
+  color: var(--md-accent-fg-color);
+  background: var(--md-accent-fg-color--transparent);
+}
+
+/* ==========================================================================
+   Print: hide interactive elements
+   ========================================================================== */
+
+@media print {
+  .bookmark-star,
+  .bookmarks-container,
+  .related-pages {
+    display: none !important;
+  }
+}

--- a/hooks/generate_page_index.py
+++ b/hooks/generate_page_index.py
@@ -1,0 +1,47 @@
+"""
+@module generate_page_index
+@description MkDocs hook to generate page-index.json for related pages
+@version 1.0.0
+@author Tyler Dukes
+@last_updated 2026-02-15
+@status stable
+"""
+
+import json
+import logging
+import os
+
+log = logging.getLogger("mkdocs.hooks.generate_page_index")
+
+_pages = []
+
+
+def on_page_context(context, page, config, nav):
+    """Collect page metadata during build."""
+    meta = page.meta or {}
+    tags = meta.get("tags", [])
+    category = meta.get("category", "")
+    title = meta.get("title", page.title or "")
+
+    if tags or category:
+        _pages.append(
+            {
+                "url": page.url,
+                "title": title,
+                "tags": tags if isinstance(tags, list) else [tags],
+                "category": category,
+            }
+        )
+    return context
+
+
+def on_post_build(config):
+    """Write collected page metadata to page-index.json."""
+    site_dir = config["site_dir"]
+    output_path = os.path.join(site_dir, "page-index.json")
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(_pages, f, ensure_ascii=False)
+
+    log.info(f"Generated page-index.json with {len(_pages)} pages")
+    _pages.clear()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,11 +37,16 @@ plugins:
   - mike:
       alias_type: symlink
       canonical_version: latest
+hooks:
+  - hooks/generate_page_index.py
 extra_css:
   - stylesheets/print.css
   - stylesheets/toc.css
+  - stylesheets/features.css
 extra_javascript:
   - javascripts/shortcuts.js
+  - javascripts/related-pages.js
+  - javascripts/bookmarks.js
 extra:
   version:
     provider: mike


### PR DESCRIPTION
## Summary

- Adds auto-generated **"See Also" related pages** at the bottom of each documentation page, calculated from tag similarity in frontmatter metadata
- Adds a **localStorage-based bookmarks system** with star icons on page headings and a header dropdown showing saved bookmarks and recently viewed pages
- Implements a MkDocs build hook (`hooks/generate_page_index.py`) that generates a `page-index.json` with all page metadata (127 pages) for client-side related page calculation

Closes #294

## New Files

| File | Purpose |
|------|---------|
| `hooks/generate_page_index.py` | MkDocs hook - collects page metadata (title, tags, category, URL) during build and writes `page-index.json` to site output |
| `docs/javascripts/related-pages.js` | Fetches `page-index.json`, calculates tag-based similarity scores, and renders a "See Also" section with up to 5 related pages |
| `docs/javascripts/bookmarks.js` | LocalStorage bookmarks with star icon on `<h1>`, header dropdown with bookmarks list + recently viewed pages |
| `docs/stylesheets/features.css` | Styles for related pages grid, bookmark star, header dropdown, badges, and print-media hiding |

## How It Works

**Related Pages:**
- Build hook collects `tags` and `category` from YAML frontmatter across all 127 doc pages
- JavaScript calculates Jaccard-like similarity (shared tags + category bonus) at page load
- Renders top 5 related pages in a responsive grid at page bottom

**Bookmarks:**
- Star icon appended to each page's `<h1>` heading
- Bookmark icon in header with count badge and dropdown panel
- Two sections in dropdown: saved bookmarks (with remove button) and recently viewed (last 10 pages)
- All data persisted in `localStorage` (`dsg-bookmarks`, `dsg-recent-pages`)

## Test plan

- [ ] Run `mkdocs build --strict` — verify no new errors and `page-index.json` is generated in `site/`
- [ ] Run `mkdocs serve` — verify related pages appear at bottom of language guide pages
- [ ] Verify bookmark star appears next to page `<h1>` headings
- [ ] Click star to bookmark, verify it persists across page navigation
- [ ] Open bookmarks dropdown in header, verify bookmarks and recently viewed lists
- [ ] Remove a bookmark from dropdown, verify star updates on corresponding page
- [ ] Verify print styles hide interactive elements
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)