### PR TITLE
fix(docs): replace broken CNCF supply chain security link

### DIFF
--- a/docs/05_ci_cd/code_signing_guide.md
+++ b/docs/05_ci_cd/code_signing_guide.md
@@ -1621,7 +1621,7 @@ EOF
 ### Learning Resources
 
 - [Sigstore The Hard Way](https://github.com/lukehinds/sigstore-the-hard-way)
-- [Software Supply Chain Security](https://www.cncf.io/blog/2021/12/14/improving-software-supply-chain-security/)
+- [Software Supply Chain Security Best Practices v2](https://tag-security.cncf.io/blog/software-supply-chain-security-best-practices-v2/)
 - [SLSA Framework](https://slsa.dev/)
 - [Supply-chain Levels for Software Artifacts](https://github.com/slsa-framework/slsa)
 


### PR DESCRIPTION
## Summary

- Fixes broken link detected by the automated link checker (issue #300)
- The CNCF blog post at `/blog/2021/12/14/improving-software-supply-chain-security/` returns HTTP 404
- Replaced with the current CNCF TAG Security blog post: [Software Supply Chain Security Best Practices v2](https://tag-security.cncf.io/blog/software-supply-chain-security-best-practices-v2/)

## Test plan

- [ ] Verify the new URL resolves successfully (it was confirmed live before this PR)
- [ ] Confirm link checker passes in CI

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)