### PR TITLE
fix(ci): fix release workflow changelog push and uv PATH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN }}
 
       - name: Configure git
         run: |
@@ -154,13 +154,13 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Add uv to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: |
-          uv sync
+        run: uv sync
 
       - name: Generate Changelog
         run: |


### PR DESCRIPTION
## Summary

- Use `AUTO_MERGE_TOKEN` instead of `GITHUB_TOKEN` for the checkout in `update-version` job so git push can bypass `main` branch protection (GITHUB_TOKEN is blocked by GH006)
- Fix uv install PATH from `$HOME/.cargo/bin` → `$HOME/.local/bin`, matching the pattern in `ci.yml` (uv installs to `~/.local/bin` on Linux)
- Split uv install and PATH export into separate steps for consistency with `ci.yml`

## Test plan

- [ ] Trigger **Actions → Automated Release → Run workflow** and confirm it runs to completion
- [ ] Verify `pyproject.toml` version is bumped and committed to `main`
- [ ] Verify `docs/changelog.md` is regenerated and committed to `main`
- [ ] Confirm no "GH006 Protected branch update failed" error in logs
- [ ] Confirm `uv sync` step succeeds (no "command not found")

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)