### PR TITLE
fix(docs): resolve broken links (closes #350)

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -386,6 +386,21 @@
     },
     {
       "pattern": "^https://github.com/your-org"
+    },
+    {
+      "pattern": "^https://github.com/org/repo"
+    },
+    {
+      "pattern": "^https://github.com/tydukes/coding-style-guide/pkgs/"
+    },
+    {
+      "pattern": "^https://www.hhs.gov"
+    },
+    {
+      "pattern": "^https://gatling.io"
+    },
+    {
+      "pattern": "^https://www.datanami.com"
     }
   ],
   "replacementPatterns": [

--- a/docs/02_language_guides/bicep.md
+++ b/docs/02_language_guides/bicep.md
@@ -2717,7 +2717,7 @@ trim_trailing_whitespace = false
 - [Bicep VS Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep)
 - [PSRule for Azure](https://azure.github.io/PSRule.Rules.Azure/)
 - [Azure CLI](https://learn.microsoft.com/cli/azure/)
-- [Bicep Playground](https://bicepdemo.z22.web.core.windows.net/)
+- [Bicep Playground](https://azure.github.io/bicep/)
 
 ### Related Guides
 

--- a/docs/02_language_guides/crossplane.md
+++ b/docs/02_language_guides/crossplane.md
@@ -2983,7 +2983,7 @@ spec:
 - [Crossplane Documentation](https://docs.crossplane.io/)
 - [Crossplane GitHub Repository](https://github.com/crossplane/crossplane)
 - [Upbound Marketplace](https://marketplace.upbound.io/)
-- [Composition Functions](https://docs.crossplane.io/latest/concepts/composition-functions/)
+- [Composition Functions](https://docs.crossplane.io/latest/composition/compositions/)
 - [Crossplane CLI Reference](https://docs.crossplane.io/latest/cli/)
 
 ### Related Guides

--- a/docs/02_language_guides/pulumi.md
+++ b/docs/02_language_guides/pulumi.md
@@ -3027,7 +3027,7 @@ repos:
 ### Official Documentation
 
 - [Pulumi Documentation](https://www.pulumi.com/docs/)
-- [Pulumi API Reference](https://www.pulumi.com/docs/reference/pkg/)
+- [Pulumi Registry](https://www.pulumi.com/registry/)
 - [Pulumi Examples](https://github.com/pulumi/examples)
 - [Pulumi Blog](https://www.pulumi.com/blog/)
 

--- a/docs/02_language_guides/repl.md
+++ b/docs/02_language_guides/repl.md
@@ -2157,7 +2157,7 @@ false
 - [kubectl exec Documentation](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/)
 - [kubectl debug Documentation](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_debug/)
 - [PostgreSQL psql Documentation](https://www.postgresql.org/docs/current/app-psql.html)
-- [Redis CLI Documentation](https://redis.io/docs/connect/cli/)
+- [Redis CLI Documentation](https://redis.io/docs/latest/develop/tools/cli/)
 - [MySQL Client Documentation](https://dev.mysql.com/doc/refman/8.0/en/mysql.html)
 
 ### Enhanced REPL Tools

--- a/docs/02_language_guides/task_runners.md
+++ b/docs/02_language_guides/task_runners.md
@@ -2012,7 +2012,7 @@ deploy:
 
 - [Just Official Documentation](https://just.systems/man/en/)
 - [Just GitHub Repository](https://github.com/casey/just)
-- [Just Language Reference](https://just.systems/man/en/chapter_1.html)
+- [Just Language Reference](https://just.systems/man/en/)
 
 ### Related Guides
 

--- a/docs/05_ci_cd/observability_guide.md
+++ b/docs/05_ci_cd/observability_guide.md
@@ -5152,7 +5152,7 @@ except Exception as e:
 - [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
 - [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
 - [Jaeger Documentation](https://www.jaegertracing.io/docs/)
-- [Zipkin Documentation](https://zipkin.io/pages/documentation.html)
+- [Zipkin Documentation](https://zipkin.io/)
 
 ### Metrics and Monitoring
 


### PR DESCRIPTION
## Summary

Fixes all broken links detected by the automated link checker in issue #350.

**URL updates (404s):**
- `crossplane.md`: Composition Functions → new docs structure (`/composition/compositions/`)
- `task_runners.md`: Just chapter_1.html → current manual root (`/man/en/`)
- `pulumi.md`: Pulumi API Reference (`/docs/reference/pkg/`) → Pulumi Registry (`/registry/`)
- `repl.md`: Redis CLI (`/docs/connect/cli/`) → updated path (`/docs/latest/develop/tools/cli/`)
- `bicep.md`: Bicep Playground (dead domain) → `azure.github.io/bicep/`
- `observability_guide.md`: Zipkin Documentation page → zipkin.io homepage

**Link checker exclusions added (403 bot-blocking sites):**
- `www.hhs.gov` — valid HIPAA security rule page, site blocks automated checkers
- `gatling.io` — valid Gatling docs page, site blocks automated checkers
- `www.datanami.com` — valid article URL, site blocks automated checkers

**Link checker exclusions added (placeholder/template URLs):**
- `github.com/org/repo` — example URLs used in changelog_automation_guide.md templates
- `github.com/tydukes/coding-style-guide/pkgs/` — container package page (may not exist until first container publish)

## Test plan

- [ ] Verify CI passes (link-checker workflow should no longer fail)
- [ ] Confirm all replaced URLs resolve correctly
- [ ] Confirm excluded 403 URLs are legitimate (not truly broken)

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)