### PR TITLE
fix(docs): resolve broken links and bump version to v1.8.1 (closes #358)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,22 @@ This changelog is automatically generated from GitHub releases. Each release inc
 
 Changes that are in the main branch but not yet released.
 
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.1...HEAD>
+
+## [v1.8.1] - 2026-02-21
+
+### 🐛 Bug Fixes
+
+* fix(docs): resolve broken links detected in issue #358 — links to v1.8.0 release and compare URL are now valid
+
+### 📖 Documentation
+
+* docs: full site audit — refresh overview pages, refactor Getting Started, fix governance (closes #359) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/360>
+
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.0...v1.8.1>
+
+[View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.1)
+
 ## [v1.8.0] - 2026-02-21
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coding-style-guide"
-version = "1.8.0"
+version = "1.8.1"
 description = "Comprehensive coding style guide and best practices documentation"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

- Resolves broken links flagged by the automated link checker in #358
- Bumps version from `v1.8.0` → `v1.8.1` in `pyproject.toml`
- Adds `v1.8.1` changelog entry covering the site audit (#360) and this fix

## Root Cause

The link checker ran against commit `b99ece46` (which became the `v1.8.0` tag) and found two 404s:

- `https://github.com/tydukes/coding-style-guide/compare/v1.8.0...HEAD` — referenced in the `[Unreleased]` section of the changelog before the release existed
- `https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.0` — referenced in the changelog before the GitHub release was published

Both URLs now return **200 OK** — the `v1.8.0` release was published at 01:38 UTC on 2026-02-21, roughly 13 minutes after the link checker ran at 01:25 UTC.

## Changes

- `pyproject.toml`: `1.8.0` → `1.8.1`
- `docs/changelog.md`: Added `v1.8.1` release section; updated `[Unreleased]` compare URL to point to `v1.8.1...HEAD`

## Test plan

- [ ] CI link checker passes on this branch
- [ ] Changelog renders correctly in `mkdocs serve`
- [ ] `pyproject.toml` version is `1.8.1`

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)