### PR TITLE
fix(docs): add missing config examples to python guide — fixes 3:1 ratio

### DIFF
--- a/docs/02_language_guides/python.md
+++ b/docs/02_language_guides/python.md
@@ -652,9 +652,28 @@ API_KEY = "sk_live_abc123xyz..."  # Committed to git!
   - Configuration: `.flake8` or `setup.cfg`
   - Run: `flake8 .`
 
+```ini
+# .flake8
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+exclude = .git, __pycache__, .venv, dist, build
+per-file-ignores =
+    tests/*: S101
+```
+
 - **Pylint**: Comprehensive code analysis
   - Installation: `pip install pylint`
   - Run: `pylint src/`
+
+```ini
+# .pylintrc (generate full file: pylint --generate-rcfile > .pylintrc)
+[MESSAGES CONTROL]
+disable = C0114, C0115, C0116
+
+[FORMAT]
+max-line-length = 100
+```
 
 ### Type Checkers
 
@@ -662,6 +681,16 @@ API_KEY = "sk_live_abc123xyz..."  # Committed to git!
   - Installation: `pip install mypy`
   - Configuration: `mypy.ini`
   - Run: `mypy src/`
+
+```ini
+# mypy.ini
+[mypy]
+python_version = 3.11
+warn_return_any = True
+warn_unused_configs = True
+disallow_untyped_defs = True
+ignore_missing_imports = True
+```
 
 ### Testing
 


### PR DESCRIPTION
## Summary

The Python guide's Recommended Tools section described `.flake8` and `mypy.ini` config files but never showed them. Added standalone config file examples for Flake8, Pylint, and mypy alongside the existing prose descriptions.

These are complementary to (not duplicating) the `pyproject.toml` equivalents already in the "Code Quality Tools" section — some teams prefer separate ini-style config files.

## Result

| Metric | Before | After |
|--------|--------|-------|
| Code lines | 1,012 | 1,032 |
| Ratio | 2.99:1 ❌ | 3.05:1 ✅ |
| Guides passing | 34/36 | 35/36 |

## Test plan

- [x] `uv run python scripts/analyze_code_ratio.py` — python guide passes at 3.05:1
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)