### PR TITLE
fix(scripts): exempt comparison_matrix from 3:1 ratio check

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Code-to-Text Ratio](https://img.shields.io/badge/code--to--text%20ratio-7.76:1-brightgreen.svg)](https://tydukes.github.io/coding-style-guide/project_status/)
-[![Guides Passing](https://img.shields.io/badge/guides%20passing-34%2F36-success.svg)](https://tydukes.github.io/coding-style-guide/project_status/)
+[![Guides Passing](https://img.shields.io/badge/guides%20passing-35%2F35-success.svg)](https://tydukes.github.io/coding-style-guide/project_status/)
 [![Documentation Pages](https://img.shields.io/badge/docs%20pages-73-blue.svg)](https://tydukes.github.io/coding-style-guide/)
 [![Version](https://img.shields.io/github/v/release/tydukes/coding-style-guide)](https://github.com/tydukes/coding-style-guide/releases)
 [![Last Commit](https://img.shields.io/github/last-commit/tydukes/coding-style-guide)](https://github.com/tydukes/coding-style-guide/commits/main)


### PR DESCRIPTION
## Summary

`comparison_matrix` is a cross-language reference table. Its value is in structured tabular data, not code examples — applying the 3:1 ratio metric to it is not meaningful (current ratio: 0.05:1).

## Changes

- Add `EXEMPT_GUIDES` set to `analyze_code_ratio.py`
- Exempt guides show `⬜ EXEMPT` status and are excluded from totals and pass/fail count
- Exemption list printed below results table for visibility
- Also fixes a pre-existing bug where the `below_target` summary loop used outer-scope `code_lines`/`text_lines` variables instead of the per-guide values

## Result

```
comparison_matrix     19     361    0.05   ⬜ EXEMPT
...
Exempt:  1 guide(s) — comparison_matrix
Achievement: 35/35 guides pass
```

- README badge updated: `34/36` → `35/35`

## Test plan

- [x] `uv run python scripts/analyze_code_ratio.py` — 35/35 pass, comparison_matrix shown as exempt
- [x] `uv run black .` and `uv run flake8` pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)