### PR TITLE
feat(ui): enable navigation.instant and navigation.instant.progress

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,12 @@ This changelog is automatically generated from GitHub releases. Each release inc
 
 Changes that are in the main branch but not yet released.
 
+## [v1.8.11] - 2026-02-22
+
+## What's Changed
+### New Features
+* feat(ui): enable `navigation.instant` and `navigation.instant.progress` for SPA-style navigation (#381)
+
 ## [v1.8.10] - 2026-02-22
 
 ## What's Changed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,8 @@ theme:
   name: material
   language: en
   features:
+    - navigation.instant
+    - navigation.instant.progress
     - navigation.tabs
     - navigation.top
     - toc.follow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coding-style-guide"
-version = "1.8.10"
+version = "1.8.11"
 description = "Comprehensive coding style guide and best practices documentation"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

- Enables `navigation.instant` for SPA-style client-side navigation (no full page reloads)
- Enables `navigation.instant.progress` for a visible progress bar on page load
- Bumps version to `1.8.11`

## Context

Closes #381.

The custom `bookmarks.js` and `related-pages.js` scripts already subscribe to Material's `location$` observable to handle instant navigation — no JS changes required.

## Test plan

- [ ] `mkdocs serve` locally — navigate between pages and verify no full reload occurs
- [ ] Progress bar appears on page transitions
- [ ] Bookmarks persist and related-pages section renders correctly after navigation
- [ ] No JS console errors on page transitions
- [ ] `uv run mkdocs build --strict` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)