### PR TITLE
fix(ui): add edit_uri so content.action.edit button resolves correctly

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,12 @@ This changelog is automatically generated from GitHub releases. Each release inc
 
 Changes that are in the main branch but not yet released.
 
+## [v1.8.16] - 2026-02-22
+
+## What's Changed
+### Bug Fixes
+* fix(ui): add `edit_uri` to mkdocs.yml so the edit-this-page button resolves correctly (#383)
+
 ## [v1.8.15] - 2026-02-22
 
 ## What's Changed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_author: "Tyler Dukes"
 site_url: "https://tydukes.github.io/coding-style-guide/"
 repo_url: "https://github.com/tydukes/coding-style-guide"
 repo_name: "coding-style-guide"
+edit_uri: "edit/main/docs/"
 theme:
   name: material
   language: en

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coding-style-guide"
-version = "1.8.15"
+version = "1.8.16"
 description = "Comprehensive coding style guide and best practices documentation"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

- Adds `edit_uri: "edit/main/docs/"` to `mkdocs.yml`
- Fixes the 404 returned when clicking the "Edit this page" button
- Bumps version to `1.8.16`

## Context

Closes #392.

`content.action.edit` was enabled in #383 but `edit_uri` was not set. Without it, Material for MkDocs cannot construct the correct GitHub edit URL. The button rendered but linked to a path that doesn't exist.

With `edit_uri: "edit/main/docs/"`, Material appends the page's relative path to produce:

```
https://github.com/tydukes/coding-style-guide/edit/main/docs/{page}.md
```

## Test plan

- [ ] Click "Edit this page" on any doc page — should open the correct file on GitHub
- [ ] `uv run mkdocs build --strict` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)