### PR TITLE
docs(aws): scaffold aws.md — overview, account hierarchy, naming, and tagging

### DIFF
--- a/docs/11_cloud_providers/aws.md
+++ b/docs/11_cloud_providers/aws.md
@@ -1,0 +1,830 @@
+---
+title: "Amazon Web Services Best Practices Guide"
+description: "Comprehensive AWS cloud provider best practices for infrastructure as code, security, networking, and cost optimization"
+author: "Tyler Dukes"
+tags: [aws, amazon, cloud, terraform, iac, security, networking, eks, iam]
+category: "Cloud Providers"
+status: "active"
+search_keywords: [aws, amazon, cloud provider, infrastructure, terraform, security, organizations, landing zone]
+---
+
+## Overview
+
+**Amazon Web Services (AWS)** is the world's most broadly adopted cloud platform, offering 200+
+fully-featured services across compute, storage, networking, databases, AI/ML, and more. This guide
+covers AWS-specific patterns, security standards, and infrastructure best practices optimized for
+Terraform and Terragrunt deployments.
+
+### Key Characteristics
+
+- **Global Footprint**: 33+ regions, 105+ availability zones, 600+ edge locations
+- **Breadth of Services**: Largest service catalog of any cloud provider
+- **Security Depth**: Shared responsibility model, native compliance tooling (GuardDuty, Security Hub, Config)
+- **IaC Ecosystem**: First-class Terraform provider, CDK, CloudFormation, and SAM support
+- **Compliance**: 143+ security standards and compliance certifications
+
+---
+
+## Quick Reference
+
+| **Category** | **Convention** | **Example** | **Notes** |
+|---|---|---|---|
+| **Resource Naming** | | | |
+| Format | `{workload}-{env}-{region}-{resource}` | `payments-prod-use1-eks` | Lowercase, hyphens |
+| S3 Buckets | `{org}-{workload}-{purpose}-{env}-{region}` | `acme-payments-logs-prod-use1` | Globally unique |
+| IAM Roles | `{workload}-{env}-{role}` | `payments-prod-eks-node` | No region (global) |
+| VPCs | `{workload}-{env}-{region}-vpc` | `payments-prod-use1-vpc` | One per account/region |
+| Security Groups | `{workload}-{env}-{role}-sg` | `payments-prod-app-sg` | Descriptive role |
+| EKS Clusters | `{workload}-{env}-{region}-eks` | `payments-prod-use1-eks` | Include region |
+| **Tagging** | | | |
+| Required Tags | `Environment`, `Owner`, `CostCenter`, `Project`, `ManagedBy` | See examples below | Enforce via Config + SCP |
+| **Terraform** | | | |
+| Provider Version | `~> 5.0` | `version = "~> 5.0"` | Pin major version |
+| State Backend | S3 + DynamoDB | `s3` backend | Versioning + locking |
+| **Security** | | | |
+| Authentication | IAM Roles + OIDC | IRSA, GitHub Actions OIDC | No long-lived credentials |
+| Secrets | Secrets Manager | `aws_secretsmanager_secret` | Never in code or state |
+| Network | Security Groups + VPC Endpoints | Defense in depth | No public endpoints |
+
+---
+
+## AWS Account Hierarchy
+
+### Organization Structure
+
+```hcl
+# management/organizations.tf
+# Root AWS Organizations configuration with OU structure
+
+resource "aws_organizations_organization" "root" {
+  aws_service_access_principals = [
+    "cloudtrail.amazonaws.com",
+    "config.amazonaws.com",
+    "guardduty.amazonaws.com",
+    "securityhub.amazonaws.com",
+    "sso.amazonaws.com",
+    "ram.amazonaws.com",
+    "billing.amazonaws.com",
+    "cost-optimization-hub.bcm.amazonaws.com",
+  ]
+
+  feature_set          = "ALL"
+  enabled_policy_types = ["SERVICE_CONTROL_POLICY", "TAG_POLICY", "BACKUP_POLICY"]
+}
+
+# Root OU: Infrastructure
+resource "aws_organizations_organizational_unit" "infrastructure" {
+  name      = "Infrastructure"
+  parent_id = aws_organizations_organization.root.roots[0].id
+}
+
+# Root OU: Workloads
+resource "aws_organizations_organizational_unit" "workloads" {
+  name      = "Workloads"
+  parent_id = aws_organizations_organization.root.roots[0].id
+}
+
+# Root OU: Sandbox
+resource "aws_organizations_organizational_unit" "sandbox" {
+  name      = "Sandbox"
+  parent_id = aws_organizations_organization.root.roots[0].id
+}
+
+# Workloads: Production
+resource "aws_organizations_organizational_unit" "production" {
+  name      = "Production"
+  parent_id = aws_organizations_organizational_unit.workloads.id
+}
+
+# Workloads: Non-Production
+resource "aws_organizations_organizational_unit" "non_production" {
+  name      = "NonProduction"
+  parent_id = aws_organizations_organizational_unit.workloads.id
+}
+```
+
+### Landing Zone Account Structure
+
+```hcl
+# management/accounts.tf
+# Core platform accounts — one per function
+
+resource "aws_organizations_account" "log_archive" {
+  name              = "log-archive"
+  email             = "aws-log-archive@example.com"
+  parent_id         = aws_organizations_organizational_unit.infrastructure.id
+  role_name         = "OrganizationAccountAccessRole"
+  close_on_deletion = false
+
+  tags = {
+    Environment = "prod"
+    Purpose     = "centralized-logging"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_organizations_account" "audit" {
+  name              = "audit"
+  email             = "aws-audit@example.com"
+  parent_id         = aws_organizations_organizational_unit.infrastructure.id
+  role_name         = "OrganizationAccountAccessRole"
+  close_on_deletion = false
+
+  tags = {
+    Environment = "prod"
+    Purpose     = "security-tooling"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_organizations_account" "network" {
+  name              = "network"
+  email             = "aws-network@example.com"
+  parent_id         = aws_organizations_organizational_unit.infrastructure.id
+  role_name         = "OrganizationAccountAccessRole"
+  close_on_deletion = false
+
+  tags = {
+    Environment = "prod"
+    Purpose     = "shared-networking"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_organizations_account" "workload_prod" {
+  name              = "payments-prod"
+  email             = "aws-payments-prod@example.com"
+  parent_id         = aws_organizations_organizational_unit.production.id
+  role_name         = "OrganizationAccountAccessRole"
+  close_on_deletion = false
+
+  tags = {
+    Environment = "prod"
+    Project     = "payments"
+    ManagedBy   = "terraform"
+  }
+}
+```
+
+### Service Control Policies
+
+```hcl
+# management/scps.tf
+# Preventative guardrails applied at the OU level
+
+# Deny actions that would compromise the security baseline
+resource "aws_organizations_policy" "deny_root_user" {
+  name        = "DenyRootUserActions"
+  description = "Prevents root user actions across all member accounts"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyRootUser"
+        Effect   = "Deny"
+        Action   = "*"
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::*:root"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy" "deny_leave_org" {
+  name        = "DenyLeaveOrganization"
+  description = "Prevents accounts from leaving the organization"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyLeaveOrg"
+        Effect   = "Deny"
+        Action   = "organizations:LeaveOrganization"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy" "deny_disable_security" {
+  name        = "DenyDisableSecurityServices"
+  description = "Prevents disabling of GuardDuty, Security Hub, Config, and CloudTrail"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DenyDisableGuardDuty"
+        Effect = "Deny"
+        Action = [
+          "guardduty:DeleteDetector",
+          "guardduty:DisassociateFromMasterAccount",
+          "guardduty:StopMonitoringMembers",
+          "guardduty:UpdateDetector",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "DenyDisableSecurityHub"
+        Effect = "Deny"
+        Action = [
+          "securityhub:DeleteHub",
+          "securityhub:DisableSecurityHub",
+          "securityhub:DisassociateFromMasterAccount",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "DenyDisableConfig"
+        Effect = "Deny"
+        Action = [
+          "config:DeleteConfigRule",
+          "config:DeleteConfigurationRecorder",
+          "config:DeleteDeliveryChannel",
+          "config:StopConfigurationRecorder",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "DenyDisableCloudTrail"
+        Effect = "Deny"
+        Action = [
+          "cloudtrail:DeleteTrail",
+          "cloudtrail:StopLogging",
+          "cloudtrail:UpdateTrail",
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Attach SCPs to OUs
+resource "aws_organizations_policy_attachment" "deny_root_workloads" {
+  policy_id = aws_organizations_policy.deny_root_user.id
+  target_id = aws_organizations_organizational_unit.workloads.id
+}
+
+resource "aws_organizations_policy_attachment" "deny_leave_all" {
+  policy_id = aws_organizations_policy.deny_leave_org.id
+  target_id = aws_organizations_organization.root.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "deny_disable_security_workloads" {
+  policy_id = aws_organizations_policy.deny_disable_security.id
+  target_id = aws_organizations_organizational_unit.workloads.id
+}
+```
+
+### Cross-Account Role Assumption
+
+```hcl
+# modules/cross-account/main.tf
+# Standard pattern for cross-account access from a central CI/CD account
+
+data "aws_iam_policy_document" "assume_role_cicd" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.cicd_account_id}:role/github-actions-deployer"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [var.external_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "cross_account_deploy" {
+  name               = "${var.workload}-${var.environment}-cross-account-deploy"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_cicd.json
+  max_session_duration = 3600
+
+  tags = local.common_tags
+}
+```
+
+---
+
+## Resource Naming Conventions
+
+### Naming Locals Module
+
+```hcl
+# modules/naming/main.tf
+# Centralized AWS naming convention module
+
+variable "workload" {
+  description = "Workload or application name"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{2,19}$", var.workload))
+    error_message = "Workload must be lowercase alphanumeric with hyphens, 3-20 characters."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod", "sandbox"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod, sandbox."
+  }
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "org" {
+  description = "Organization short name for globally unique resources"
+  type        = string
+}
+
+locals {
+  # AWS region short codes for compact names
+  region_short = {
+    "us-east-1"      = "use1"
+    "us-east-2"      = "use2"
+    "us-west-1"      = "usw1"
+    "us-west-2"      = "usw2"
+    "eu-west-1"      = "euw1"
+    "eu-west-2"      = "euw2"
+    "eu-central-1"   = "euc1"
+    "ap-southeast-1" = "apse1"
+    "ap-southeast-2" = "apse2"
+    "ap-northeast-1" = "apne1"
+    "ca-central-1"   = "cac1"
+  }
+
+  region_code = lookup(local.region_short, var.region, replace(var.region, "-", ""))
+
+  # Base naming pattern: {workload}-{env}-{region}
+  base = "${var.workload}-${var.environment}-${local.region_code}"
+
+  names = {
+    # VPC
+    vpc             = "${local.base}-vpc"
+    # Subnets
+    subnet_public   = "${local.base}-public"
+    subnet_private  = "${local.base}-private"
+    subnet_intra    = "${local.base}-intra"
+    # EKS
+    eks_cluster     = "${local.base}-eks"
+    eks_node_group  = "${local.base}-ng"
+    # ECS
+    ecs_cluster     = "${local.base}-ecs"
+    # Lambda (no region constraint — add function suffix per call)
+    lambda_prefix   = "${var.workload}-${var.environment}"
+    # RDS
+    rds_instance    = "${local.base}-rds"
+    rds_cluster     = "${local.base}-aurora"
+    # ElastiCache
+    elasticache     = "${local.base}-redis"
+    # Security Groups (no region — descriptive role suffix)
+    sg_prefix       = "${var.workload}-${var.environment}"
+    # IAM Roles (global — no region)
+    iam_role_prefix = "${var.workload}-${var.environment}"
+    # S3 (globally unique — include org prefix)
+    s3_prefix       = "${var.org}-${var.workload}"
+    # ECR (no region in name — registry is regional)
+    ecr_prefix      = "${var.workload}"
+    # CloudWatch Log Groups
+    log_group       = "/aws/${var.workload}/${var.environment}"
+    # KMS
+    kms_alias       = "alias/${var.workload}/${var.environment}"
+    # Secrets Manager
+    secret_prefix   = "${var.workload}/${var.environment}"
+  }
+}
+
+output "names" {
+  description = "Map of standardized resource names"
+  value       = local.names
+}
+
+output "base" {
+  description = "Base name for custom resource naming"
+  value       = local.base
+}
+
+output "region_code" {
+  description = "Short region code used in names"
+  value       = local.region_code
+}
+```
+
+### Using the Naming Module
+
+```hcl
+# main.tf
+# Consume the naming module for consistent resource names
+
+module "naming" {
+  source = "./modules/naming"
+
+  org         = "acme"
+  workload    = "payments"
+  environment = "prod"
+  region      = "us-east-1"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name = module.naming.names.vpc
+  })
+}
+
+resource "aws_eks_cluster" "main" {
+  name     = module.naming.names.eks_cluster
+  role_arn = aws_iam_role.eks_cluster.arn
+  version  = "1.31"
+
+  vpc_config {
+    subnet_ids              = aws_subnet.private[*].id
+    endpoint_private_access = true
+    endpoint_public_access  = false
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket = "${module.naming.names.s3_prefix}-artifacts-prod-use1"
+
+  tags = local.common_tags
+}
+```
+
+### S3 Bucket Naming Rules
+
+```hcl
+# s3-naming.tf
+# S3 has strict global uniqueness requirements
+
+locals {
+  # S3 bucket names: {org}-{workload}-{purpose}-{env}-{region}
+  # Must be 3-63 chars, globally unique, DNS-compliant, no uppercase
+  buckets = {
+    artifacts  = "${var.org}-${var.workload}-artifacts-${var.environment}-${local.region_code}"
+    logs       = "${var.org}-${var.workload}-logs-${var.environment}-${local.region_code}"
+    tf_state   = "${var.org}-terraform-state-${local.region_code}"
+    backups    = "${var.org}-${var.workload}-backups-${var.environment}-${local.region_code}"
+    data       = "${var.org}-${var.workload}-data-${var.environment}-${local.region_code}"
+  }
+}
+
+# Validate bucket names do not exceed 63 characters
+resource "null_resource" "validate_bucket_names" {
+  for_each = local.buckets
+
+  lifecycle {
+    precondition {
+      condition     = length(each.value) <= 63
+      error_message = "S3 bucket name '${each.value}' exceeds 63 characters."
+    }
+    precondition {
+      condition     = can(regex("^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", each.value))
+      error_message = "S3 bucket name '${each.value}' contains invalid characters."
+    }
+  }
+}
+```
+
+### IAM Resource Naming
+
+```hcl
+# iam-naming.tf
+# IAM resources are global — no region in the name
+
+locals {
+  # IAM roles: {workload}-{env}-{component}-role
+  iam_roles = {
+    eks_cluster   = "${var.workload}-${var.environment}-eks-cluster-role"
+    eks_node      = "${var.workload}-${var.environment}-eks-node-role"
+    eks_pod       = "${var.workload}-${var.environment}-eks-pod-role"
+    lambda        = "${var.workload}-${var.environment}-lambda-role"
+    ecs_task      = "${var.workload}-${var.environment}-ecs-task-role"
+    ecs_execution = "${var.workload}-${var.environment}-ecs-execution-role"
+    github_oidc   = "${var.workload}-${var.environment}-github-oidc-role"
+    rds_enhanced  = "${var.workload}-${var.environment}-rds-monitoring-role"
+  }
+
+  # IAM policies: {workload}-{env}-{purpose}-policy
+  iam_policies = {
+    s3_read     = "${var.workload}-${var.environment}-s3-read-policy"
+    s3_write    = "${var.workload}-${var.environment}-s3-write-policy"
+    secrets     = "${var.workload}-${var.environment}-secrets-read-policy"
+    ssm         = "${var.workload}-${var.environment}-ssm-read-policy"
+  }
+
+  # Instance profiles: {workload}-{env}-{component}-profile
+  instance_profiles = {
+    eks_node = "${var.workload}-${var.environment}-eks-node-profile"
+    ec2_app  = "${var.workload}-${var.environment}-ec2-app-profile"
+  }
+}
+```
+
+---
+
+## Tagging Standards
+
+### Required Tags and Provider Default Tags
+
+```hcl
+# providers.tf
+# Use default_tags to apply required tags to every resource automatically
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Owner       = var.owner
+      CostCenter  = var.cost_center
+      Project     = var.project
+      ManagedBy   = "terraform"
+      Application = var.workload
+      Repository  = var.repository
+    }
+  }
+}
+
+# Validate required variables are non-empty
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod", "sandbox"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod, sandbox."
+  }
+}
+
+variable "owner" {
+  description = "Team or individual responsible for the resource"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+@[a-z0-9-]+\\.[a-z]{2,}$", var.owner))
+    error_message = "Owner must be a valid email address."
+  }
+}
+
+variable "cost_center" {
+  description = "Cost center code for billing allocation"
+  type        = string
+
+  validation {
+    condition     = can(regex("^CC-[0-9]{4,6}$", var.cost_center))
+    error_message = "CostCenter must follow the format CC-XXXX (e.g., CC-1234)."
+  }
+}
+
+variable "project" {
+  description = "Project or product name"
+  type        = string
+}
+
+variable "repository" {
+  description = "Source code repository URL"
+  type        = string
+  default     = ""
+}
+```
+
+### Tag Enforcement via AWS Config
+
+```hcl
+# compliance/config-tag-rules.tf
+# AWS Config rules that detect and alert on missing required tags
+
+resource "aws_config_config_rule" "required_tags" {
+  name        = "${var.workload}-required-tags"
+  description = "Checks that required tags are present on all supported resources"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "REQUIRED_TAGS"
+  }
+
+  input_parameters = jsonencode({
+    tag1Key   = "Environment"
+    tag2Key   = "Owner"
+    tag3Key   = "CostCenter"
+    tag4Key   = "Project"
+    tag5Key   = "ManagedBy"
+    tag6Key   = "Application"
+  })
+
+  scope {
+    compliance_resource_types = [
+      "AWS::EC2::Instance",
+      "AWS::EC2::Volume",
+      "AWS::EC2::VPC",
+      "AWS::EC2::Subnet",
+      "AWS::RDS::DBInstance",
+      "AWS::RDS::DBCluster",
+      "AWS::S3::Bucket",
+      "AWS::Lambda::Function",
+      "AWS::EKS::Cluster",
+      "AWS::ECS::Cluster",
+      "AWS::ECS::Service",
+      "AWS::ElastiCache::ReplicationGroup",
+    ]
+  }
+
+  depends_on = [aws_config_configuration_recorder.main]
+
+  tags = local.common_tags
+}
+```
+
+### Tag Enforcement via SCP
+
+```hcl
+# management/scps-tags.tf
+# Deny creation of resources that are missing required tags
+
+resource "aws_organizations_policy" "require_tags_on_create" {
+  name        = "RequireTagsOnCreate"
+  description = "Denies creation of EC2, RDS, and S3 resources without required tags"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DenyEC2WithoutTags"
+        Effect = "Deny"
+        Action = [
+          "ec2:RunInstances",
+          "ec2:CreateVolume",
+          "ec2:CreateVpc",
+          "ec2:CreateSubnet",
+        ]
+        Resource = "*"
+        Condition = {
+          "Null" = {
+            "aws:RequestTag/Environment" = "true"
+            "aws:RequestTag/Owner"       = "true"
+            "aws:RequestTag/Project"     = "true"
+          }
+        }
+      },
+      {
+        Sid    = "DenyS3WithoutTags"
+        Effect = "Deny"
+        Action = "s3:CreateBucket"
+        Resource = "*"
+        Condition = {
+          "Null" = {
+            "aws:RequestTag/Environment" = "true"
+            "aws:RequestTag/Owner"       = "true"
+          }
+        }
+      },
+      {
+        Sid    = "DenyRDSWithoutTags"
+        Effect = "Deny"
+        Action = [
+          "rds:CreateDBInstance",
+          "rds:CreateDBCluster",
+        ]
+        Resource = "*"
+        Condition = {
+          "Null" = {
+            "aws:RequestTag/Environment" = "true"
+            "aws:RequestTag/Owner"       = "true"
+            "aws:RequestTag/CostCenter"  = "true"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy_attachment" "require_tags_workloads" {
+  policy_id = aws_organizations_policy.require_tags_on_create.id
+  target_id = aws_organizations_organizational_unit.workloads.id
+}
+```
+
+### AWS Tag Policies
+
+```hcl
+# management/tag-policies.tf
+# Tag policies enforce tag value standardization across the organization
+
+resource "aws_organizations_policy" "tag_policy_environment" {
+  name        = "TagPolicyEnvironment"
+  description = "Enforces allowed values for the Environment tag"
+  type        = "TAG_POLICY"
+
+  content = jsonencode({
+    tags = {
+      Environment = {
+        tag_key = {
+          "@@assign" = "Environment"
+        }
+        tag_value = {
+          "@@assign" = ["dev", "staging", "prod", "sandbox"]
+        }
+        enforced_for = {
+          "@@assign" = [
+            "ec2:instance",
+            "ec2:volume",
+            "rds:db",
+            "rds:cluster",
+            "s3:bucket",
+            "lambda:function",
+            "eks:cluster",
+          ]
+        }
+      }
+    }
+  })
+}
+
+resource "aws_organizations_policy" "tag_policy_managed_by" {
+  name        = "TagPolicyManagedBy"
+  description = "Enforces allowed values for the ManagedBy tag"
+  type        = "TAG_POLICY"
+
+  content = jsonencode({
+    tags = {
+      ManagedBy = {
+        tag_key = {
+          "@@assign" = "ManagedBy"
+        }
+        tag_value = {
+          "@@assign" = ["terraform", "cdk", "cloudformation", "manual"]
+        }
+        enforced_for = {
+          "@@assign" = [
+            "ec2:instance",
+            "s3:bucket",
+            "rds:db",
+          ]
+        }
+      }
+    }
+  })
+}
+
+resource "aws_organizations_policy_attachment" "tag_policy_environment" {
+  policy_id = aws_organizations_policy.tag_policy_environment.id
+  target_id = aws_organizations_organization.root.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "tag_policy_managed_by" {
+  policy_id = aws_organizations_policy.tag_policy_managed_by.id
+  target_id = aws_organizations_organization.root.roots[0].id
+}
+```
+
+### Common Tags Local
+
+```hcl
+# locals.tf
+# Standard locals block consumed by every Terraform root module
+
+locals {
+  common_tags = {
+    Environment = var.environment
+    Owner       = var.owner
+    CostCenter  = var.cost_center
+    Project     = var.project
+    ManagedBy   = "terraform"
+    Application = var.workload
+    Repository  = var.repository
+  }
+}
+
+# Usage — merge with resource-specific tags:
+# tags = merge(local.common_tags, { Name = "my-resource" })
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,24 +25,29 @@ This changelog is automatically generated from GitHub releases. Each release inc
 
 Changes that are in the main branch but not yet released.
 
+## [v1.8.18] - 2026-02-22
+
+## What's Changed
+### New Features
+* docs(aws): scaffold aws.md with overview, account hierarchy, naming conventions, and tagging (#394)
+
 ## [v1.8.17] - 2026-02-22
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
 ## What's Changed
 ### 🚀 Features
-* feat(ui): enable navigation.instant and navigation.instant.progress by @tydukes in https://github.com/tydukes/coding-style-guide/pull/386
-* feat(ui): enable navigation.footer for prev/next page links by @tydukes in https://github.com/tydukes/coding-style-guide/pull/387
-* feat(ui): enable content.action.edit for edit-this-page button by @tydukes in https://github.com/tydukes/coding-style-guide/pull/388
-* feat(ui): enable content.tabs.link for synced content tabs by @tydukes in https://github.com/tydukes/coding-style-guide/pull/389
-* feat(ui): enable navigation.path breadcrumb trail by @tydukes in https://github.com/tydukes/coding-style-guide/pull/390
+* feat(ui): enable navigation.instant and navigation.instant.progress by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/386>
+* feat(ui): enable navigation.footer for prev/next page links by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/387>
+* feat(ui): enable content.action.edit for edit-this-page button by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/388>
+* feat(ui): enable content.tabs.link for synced content tabs by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/389>
+* feat(ui): enable navigation.path breadcrumb trail by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/390>
 ### 🐛 Bug Fixes
-* fix(ui): add edit_uri so content.action.edit button resolves correctly by @tydukes in https://github.com/tydukes/coding-style-guide/pull/391
+* fix(ui): add edit_uri so content.action.edit button resolves correctly by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/391>
 ### Other Changes
-* fix(ci): exempt GitHub release tag URLs from link checker by @tydukes in https://github.com/tydukes/coding-style-guide/pull/379
+* fix(ci): exempt GitHub release tag URLs from link checker by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/379>
 
-
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.9...v1.8.17
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.9...v1.8.17>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.17)
 
@@ -52,10 +57,9 @@ Changes that are in the main branch but not yet released.
 
 ## What's Changed
 ### Other Changes
-* docs: rename guide to DevOps Engineering Style Guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/378
+* docs: rename guide to DevOps Engineering Style Guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/378>
 
-
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.8...v1.8.9
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.8...v1.8.9>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.9)
 
@@ -65,10 +69,9 @@ Changes that are in the main branch but not yet released.
 
 ## What's Changed
 ### Other Changes
-* fix(scripts): exempt comparison_matrix from 3:1 ratio check by @tydukes in https://github.com/tydukes/coding-style-guide/pull/377
+* fix(scripts): exempt comparison_matrix from 3:1 ratio check by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/377>
 
-
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.7...v1.8.8
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.7...v1.8.8>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.8)
 
@@ -78,10 +81,9 @@ Changes that are in the main branch but not yet released.
 
 ## What's Changed
 ### Other Changes
-* fix(docs): add missing config examples to python guide — fixes 3:1 ratio by @tydukes in https://github.com/tydukes/coding-style-guide/pull/376
+* fix(docs): add missing config examples to python guide — fixes 3:1 ratio by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/376>
 
-
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.6...v1.8.7
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.6...v1.8.7>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.7)
 
@@ -91,10 +93,9 @@ Changes that are in the main branch but not yet released.
 
 ## What's Changed
 ### Other Changes
-* docs(meta): rewrite CLAUDE.md — fix stale data, reduce to 237 lines by @tydukes in https://github.com/tydukes/coding-style-guide/pull/374
+* docs(meta): rewrite CLAUDE.md — fix stale data, reduce to 237 lines by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/374>
 
-
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.5...v1.8.6
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.5...v1.8.6>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.6)
 
@@ -104,10 +105,9 @@ Changes that are in the main branch but not yet released.
 
 ## What's Changed
 ### Other Changes
-* fix(docs): update README guide count and badges to reflect 36 guides by @tydukes in https://github.com/tydukes/coding-style-guide/pull/373
+* fix(docs): update README guide count and badges to reflect 36 guides by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/373>
 
-
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.4...v1.8.5
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.4...v1.8.5>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.5)
 
@@ -117,11 +117,10 @@ Changes that are in the main branch but not yet released.
 
 ## What's Changed
 ### Other Changes
-* fix(docs): repair 25 broken anchor deep-links in refactoring index by @tydukes in https://github.com/tydukes/coding-style-guide/pull/371
-* fix(docs): repair broken self-referential anchors in comparison_matrix.md by @tydukes in https://github.com/tydukes/coding-style-guide/pull/372
+* fix(docs): repair 25 broken anchor deep-links in refactoring index by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/371>
+* fix(docs): repair broken self-referential anchors in comparison_matrix.md by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/372>
 
-
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.3...v1.8.4
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.3...v1.8.4>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.4)
 
@@ -131,10 +130,9 @@ Changes that are in the main branch but not yet released.
 
 ## What's Changed
 ### Other Changes
-* docs(root): update README branding and remove stale root-level files by @tydukes in https://github.com/tydukes/coding-style-guide/pull/365
+* docs(root): update README branding and remove stale root-level files by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/365>
 
-
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.2...v1.8.3
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.2...v1.8.3>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.3)
 
@@ -153,19 +151,19 @@ Systematic audit of all 19 language guides and CI/CD templates using MCP-verifie
 * `securego/gosec@master` → `@v2.23.0`
 * `fluxcd/flux2/action@main` → `@v2.7.5`
 
-**Node.js 18 EOL (April 2025) — updated to Node.js 22 LTS**
+Node.js 18 EOL (April 2025) — updated to Node.js 22 LTS:
 * `node:18-alpine` → `node:22-alpine` across dockerfile, gitlab_ci, jenkins_groovy, docker_compose, github_actions guides and all templates
 * `gcr.io/distroless/nodejs18-debian11` → `gcr.io/distroless/nodejs20-debian12`
 * `nodejs18.x` Lambda runtime → `nodejs20.x` (Pulumi guide)
 * Node version matrices `[16,18,20]` / `[18,20,21]` / `[18,20,22]` → `[20, 22]`
 
-**Language guide version tables corrected**
+Language guide version tables corrected:
 * **Go**: Added 1.25 (active) and 1.24 (active); marked 1.23 and 1.22 as EOL; updated `go.mod` example to `go 1.24`; updated `golang:1.21` Docker images to `golang:1.24`
 * **Python**: Marked 3.9.x as EOL (EOL date Oct 2025 has passed)
 * **Kubernetes**: Version range updated 1.28–1.31 → 1.31–1.33; kubeval example updated to 1.32.0
 * **Ansible**: Version range updated 2.15–2.17 → 2.17–2.19; `min_ansible_version` 2.15→2.17; `ANSIBLE_VERSION` 2.16→2.18
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.1...v1.8.2
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.1...v1.8.2>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.2)
 
@@ -175,17 +173,17 @@ Systematic audit of all 19 language guides and CI/CD templates using MCP-verifie
 
 ### 🐛 Bug Fixes
 
-* fix(docs): resolve broken links detected by automated link checker (closes #358) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/361
+* fix(docs): resolve broken links detected by automated link checker (closes #358) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/361>
 
 ### 📖 Documentation
 
-* docs: full site audit — refresh overview pages, refactor Getting Started, fix governance (closes #359) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/360
+* docs: full site audit — refresh overview pages, refactor Getting Started, fix governance (closes #359) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/360>
 
 ## Details
 
 The automated link checker flagged two 404s at `v1.8.0` due to a race condition — the GitHub release was published 13 minutes after the link checker ran. Both URLs are now valid. This patch release formally closes that issue and bundles the concurrent documentation site audit.
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.8.0...v1.8.1
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.8.0...v1.8.1>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.1)
 
@@ -195,90 +193,90 @@ The automated link checker flagged two 404s at `v1.8.0` due to a race condition 
 
 ## What's Changed
 ### 🚀 Features
-* feat(automation): add custom Claude agents for issue creation, CLI testing, and UI review by @tydukes in https://github.com/tydukes/coding-style-guide/pull/351
+* feat(automation): add custom Claude agents for issue creation, CLI testing, and UI review by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/351>
 ### 🐛 Bug Fixes
-* fix(ci): fix release workflow changelog push and uv PATH by @tydukes in https://github.com/tydukes/coding-style-guide/pull/353
+* fix(ci): fix release workflow changelog push and uv PATH by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/353>
 ### 🔧 Maintenance
-* chore: remove obsolete and supplemental files by @tydukes in https://github.com/tydukes/coding-style-guide/pull/296
+* chore: remove obsolete and supplemental files by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/296>
 ### Other Changes
-* Fix link checker failures by excluding DNS-blocked domains and correcting internal anchors by @Copilot in https://github.com/tydukes/coding-style-guide/pull/182
-* feat: add IDE settings files for VS Code and IntelliJ (#184) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/196
-* feat: Create comprehensive Getting Started tutorial (Closes #185) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/198
-* Enhance README with comprehensive usage guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/199
-* feat: Create comprehensive language guide comparison matrix (Closes #191) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/200
-* feat: Add comprehensive plan to achieve 3:1 ratio for terraform.md (Closes #192) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/201
-* fix: resolve broken links in documentation (Closes #197) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/206
-* feat: Add interactive decision trees and flowcharts guide (Closes #188) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/207
-* feat: Add comprehensive project health dashboard (#187) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/208
-* Retire phase labels and migrate to new label taxonomy by @tydukes in https://github.com/tydukes/coding-style-guide/pull/215
-* fix: Remove broken GitHub Discussions links (#216) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/217
-* feat(automation): implement automated changelog generation and semantic versioning by @tydukes in https://github.com/tydukes/coding-style-guide/pull/218
-* Update Dependabot Configuration for Community Contributions by @tydukes in https://github.com/tydukes/coding-style-guide/pull/219
-* feat(ci): implement automated dependency version checking (#210) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/222
-* feat(ci): parameterize workflow versions for centralized management by @tydukes in https://github.com/tydukes/coding-style-guide/pull/224
-* docs(security): add GitHub Actions versioning policy to prefer version tags by @tydukes in https://github.com/tydukes/coding-style-guide/pull/225
-* feat(automation): implement automated language release tracking system by @tydukes in https://github.com/tydukes/coding-style-guide/pull/226
-* fix(ci): remove composite action due to GitHub Actions limitation by @tydukes in https://github.com/tydukes/coding-style-guide/pull/231
-* feat(terraform): add Phase 1 testing and validation examples by @tydukes in https://github.com/tydukes/coding-style-guide/pull/233
-* feat(terraform): add Phase 2 security and compliance examples (#203) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/236
-* fix(terraform): resolve Phase 2 double-fence parsing bugs and add Phase 3 networking examples by @tydukes in https://github.com/tydukes/coding-style-guide/pull/237
-* fix(docs): correct broken SECURITY.md link in sonarcloud review guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/238
-* feat(terraform): add operations and disaster recovery examples for Phase 4 by @tydukes in https://github.com/tydukes/coding-style-guide/pull/239
-* feat(ide): Complete IDE settings for all 19 supported languages (#248) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/297
-* feat(ci-cd): add comprehensive code signing standards guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/299
-* feat(devcontainer): add Dev Container and GitHub Codespaces style guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/301
-* feat(ci-cd): add seed data management and environment configuration guides by @tydukes in https://github.com/tydukes/coding-style-guide/pull/302
-* feat(ci-cd): add distributed tracing and structured logging guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/303
-* feat(ci-cd): add Prometheus, Grafana, and sampling standards to observability guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/304
-* feat(ci-cd): add comprehensive SAST/DAST security testing standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/305
-* feat(ci-cd): add comprehensive Trivy, Snyk, and SonarQube integration standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/306
-* feat(language-guide): add ArgoCD and Flux CD GitOps standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/307
-* feat(language-guide): add AWS CloudFormation best practices and standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/308
-* feat(language-guide): add Pulumi style guide for multi-cloud IaC by @tydukes in https://github.com/tydukes/coding-style-guide/pull/309
-* feat(language-guide): add Azure Bicep style guide for infrastructure as code by @tydukes in https://github.com/tydukes/coding-style-guide/pull/310
-* feat(templates): add runbook, playbook, and postmortem templates by @tydukes in https://github.com/tydukes/coding-style-guide/pull/311
-* feat(templates): add Architecture Decision Records (ADR) template by @tydukes in https://github.com/tydukes/coding-style-guide/pull/312
-* feat(docs): add changelog automation and release notes guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/313
-* feat(docs): add dependency update policies guide for Renovate and Dependabot by @tydukes in https://github.com/tydukes/coding-style-guide/pull/314
-* feat(templates): add reusable workflows and code generators templates by @tydukes in https://github.com/tydukes/coding-style-guide/pull/315
-* feat(cli): add standalone CLI tool for style guide checking by @tydukes in https://github.com/tydukes/coding-style-guide/pull/316
-* feat(docs): add AI-powered code review integration guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/317
-* feat(docs): add Diagram as Code style guide and standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/318
-* feat(docs): add performance testing standards (k6, JMeter, Gatling) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/319
-* feat(docs): add chaos engineering and synthetic monitoring standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/320
-* feat(docs): add smoke test standards for post-deployment verification by @tydukes in https://github.com/tydukes/coding-style-guide/pull/321
-* feat(docs): add Compliance as Code standards (InSpec, OPA, Sentinel) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/322
-* feat(docs): add code smell catalog with anti-patterns and fixes by @tydukes in https://github.com/tydukes/coding-style-guide/pull/323
-* feat(docs): add Task and Just task runner standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/324
-* feat(docs): add TOML and INI configuration file standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/325
-* feat(docs): add JSON Schema validation and documentation standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/326
-* feat(docs): add Jenkins Shared Libraries organization and standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/327
-* feat(docs): add Microsoft Azure cloud provider best practices guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/328
-* feat(docs): add Go programming language style guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/331
-* feat(docs): add Google Cloud Platform cloud provider best practices guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/332
-* feat(docs): add Crossplane cloud-agnostic infrastructure standards by @tydukes in https://github.com/tydukes/coding-style-guide/pull/333
-* feat(ide): add VS Code debug configuration templates by @tydukes in https://github.com/tydukes/coding-style-guide/pull/334
-* feat(docs): add REPL and interactive shell best practices guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/335
-* feat(docs): add pre-built git hooks library for common tasks (#282) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/336
-* feat(docs): add productivity shell aliases and functions collection (#283) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/337
-* feat(docs): add glossary auto-generation and documentation versioning by @tydukes in https://github.com/tydukes/coding-style-guide/pull/338
-* feat(docs): add real-world sample repository examples by @tydukes in https://github.com/tydukes/coding-style-guide/pull/340
-* feat(docs): add language interoperability guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/341
-* feat(docs): add progressive enhancement roadmap and maturity model by @tydukes in https://github.com/tydukes/coding-style-guide/pull/342
-* feat(docs): add CI/CD performance optimization guide by @tydukes in https://github.com/tydukes/coding-style-guide/pull/343
-* feat(docs): add tutorial series for common scenarios (#194) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/344
-* feat(docs): improve search functionality and discoverability (#195) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/345
-* feat(docs): add dark mode toggle, print styles, and copy code buttons by @tydukes in https://github.com/tydukes/coding-style-guide/pull/346
-* feat(docs): add quick search shortcut and sticky TOC with highlighting by @tydukes in https://github.com/tydukes/coding-style-guide/pull/347
-* feat(docs): add related pages suggestions and bookmark/favorites system by @tydukes in https://github.com/tydukes/coding-style-guide/pull/348
-* fix(docs): replace broken CNCF supply chain security link by @tydukes in https://github.com/tydukes/coding-style-guide/pull/349
-* docs(changelog): backfill changelog and bump version to v1.8.0 by @tydukes in https://github.com/tydukes/coding-style-guide/pull/356
-* fix(docs): resolve broken links (closes #350) by @tydukes in https://github.com/tydukes/coding-style-guide/pull/357
+* Fix link checker failures by excluding DNS-blocked domains and correcting internal anchors by @Copilot in <https://github.com/tydukes/coding-style-guide/pull/182>
+* feat: add IDE settings files for VS Code and IntelliJ (#184) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/196>
+* feat: Create comprehensive Getting Started tutorial (Closes #185) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/198>
+* Enhance README with comprehensive usage guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/199>
+* feat: Create comprehensive language guide comparison matrix (Closes #191) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/200>
+* feat: Add comprehensive plan to achieve 3:1 ratio for terraform.md (Closes #192) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/201>
+* fix: resolve broken links in documentation (Closes #197) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/206>
+* feat: Add interactive decision trees and flowcharts guide (Closes #188) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/207>
+* feat: Add comprehensive project health dashboard (#187) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/208>
+* Retire phase labels and migrate to new label taxonomy by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/215>
+* fix: Remove broken GitHub Discussions links (#216) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/217>
+* feat(automation): implement automated changelog generation and semantic versioning by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/218>
+* Update Dependabot Configuration for Community Contributions by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/219>
+* feat(ci): implement automated dependency version checking (#210) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/222>
+* feat(ci): parameterize workflow versions for centralized management by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/224>
+* docs(security): add GitHub Actions versioning policy to prefer version tags by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/225>
+* feat(automation): implement automated language release tracking system by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/226>
+* fix(ci): remove composite action due to GitHub Actions limitation by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/231>
+* feat(terraform): add Phase 1 testing and validation examples by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/233>
+* feat(terraform): add Phase 2 security and compliance examples (#203) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/236>
+* fix(terraform): resolve Phase 2 double-fence parsing bugs and add Phase 3 networking examples by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/237>
+* fix(docs): correct broken SECURITY.md link in sonarcloud review guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/238>
+* feat(terraform): add operations and disaster recovery examples for Phase 4 by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/239>
+* feat(ide): Complete IDE settings for all 19 supported languages (#248) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/297>
+* feat(ci-cd): add comprehensive code signing standards guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/299>
+* feat(devcontainer): add Dev Container and GitHub Codespaces style guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/301>
+* feat(ci-cd): add seed data management and environment configuration guides by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/302>
+* feat(ci-cd): add distributed tracing and structured logging guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/303>
+* feat(ci-cd): add Prometheus, Grafana, and sampling standards to observability guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/304>
+* feat(ci-cd): add comprehensive SAST/DAST security testing standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/305>
+* feat(ci-cd): add comprehensive Trivy, Snyk, and SonarQube integration standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/306>
+* feat(language-guide): add ArgoCD and Flux CD GitOps standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/307>
+* feat(language-guide): add AWS CloudFormation best practices and standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/308>
+* feat(language-guide): add Pulumi style guide for multi-cloud IaC by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/309>
+* feat(language-guide): add Azure Bicep style guide for infrastructure as code by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/310>
+* feat(templates): add runbook, playbook, and postmortem templates by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/311>
+* feat(templates): add Architecture Decision Records (ADR) template by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/312>
+* feat(docs): add changelog automation and release notes guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/313>
+* feat(docs): add dependency update policies guide for Renovate and Dependabot by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/314>
+* feat(templates): add reusable workflows and code generators templates by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/315>
+* feat(cli): add standalone CLI tool for style guide checking by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/316>
+* feat(docs): add AI-powered code review integration guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/317>
+* feat(docs): add Diagram as Code style guide and standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/318>
+* feat(docs): add performance testing standards (k6, JMeter, Gatling) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/319>
+* feat(docs): add chaos engineering and synthetic monitoring standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/320>
+* feat(docs): add smoke test standards for post-deployment verification by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/321>
+* feat(docs): add Compliance as Code standards (InSpec, OPA, Sentinel) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/322>
+* feat(docs): add code smell catalog with anti-patterns and fixes by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/323>
+* feat(docs): add Task and Just task runner standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/324>
+* feat(docs): add TOML and INI configuration file standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/325>
+* feat(docs): add JSON Schema validation and documentation standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/326>
+* feat(docs): add Jenkins Shared Libraries organization and standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/327>
+* feat(docs): add Microsoft Azure cloud provider best practices guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/328>
+* feat(docs): add Go programming language style guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/331>
+* feat(docs): add Google Cloud Platform cloud provider best practices guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/332>
+* feat(docs): add Crossplane cloud-agnostic infrastructure standards by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/333>
+* feat(ide): add VS Code debug configuration templates by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/334>
+* feat(docs): add REPL and interactive shell best practices guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/335>
+* feat(docs): add pre-built git hooks library for common tasks (#282) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/336>
+* feat(docs): add productivity shell aliases and functions collection (#283) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/337>
+* feat(docs): add glossary auto-generation and documentation versioning by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/338>
+* feat(docs): add real-world sample repository examples by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/340>
+* feat(docs): add language interoperability guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/341>
+* feat(docs): add progressive enhancement roadmap and maturity model by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/342>
+* feat(docs): add CI/CD performance optimization guide by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/343>
+* feat(docs): add tutorial series for common scenarios (#194) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/344>
+* feat(docs): improve search functionality and discoverability (#195) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/345>
+* feat(docs): add dark mode toggle, print styles, and copy code buttons by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/346>
+* feat(docs): add quick search shortcut and sticky TOC with highlighting by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/347>
+* feat(docs): add related pages suggestions and bookmark/favorites system by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/348>
+* fix(docs): replace broken CNCF supply chain security link by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/349>
+* docs(changelog): backfill changelog and bump version to v1.8.0 by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/356>
+* fix(docs): resolve broken links (closes #350) by @tydukes in <https://github.com/tydukes/coding-style-guide/pull/357>
 
 ## New Contributors
-* @Copilot made their first contribution in https://github.com/tydukes/coding-style-guide/pull/182
+* @Copilot made their first contribution in <https://github.com/tydukes/coding-style-guide/pull/182>
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.3.0...v1.8.0
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.3.0...v1.8.0>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.8.0)
 
@@ -288,43 +286,43 @@ The automated link checker flagged two 404s at `v1.8.0` due to a race condition 
 
 ### Added
 
-- Comprehensive IaC testing framework and standards ([#175](https://github.com/tydukes/coding-style-guide/pull/175))
-  - Enhanced Terraform guide with testing best practices
-  - Enhanced Ansible guide with role testing strategies
-  - GitLab CI tiered pipeline architecture
-  - IaC Testing Philosophy and Standards document
-- Production-ready code examples for Terraform guide ([#180](https://github.com/tydukes/coding-style-guide/pull/180))
-  - CI/CD pipeline examples (GitHub Actions, GitLab CI)
-  - Complete Terratest integration test suite
-  - Production modules: EKS, Monitoring, ECS, Lambda, DynamoDB
-  - 4,673 lines of deployment-ready code following best practices
-- CONTRACT.md template for IaC modules and roles
-- TESTING.md template for IaC projects
-- Code-to-text ratio analysis tool
+* Comprehensive IaC testing framework and standards ([#175](https://github.com/tydukes/coding-style-guide/pull/175))
+  * Enhanced Terraform guide with testing best practices
+  * Enhanced Ansible guide with role testing strategies
+  * GitLab CI tiered pipeline architecture
+  * IaC Testing Philosophy and Standards document
+* Production-ready code examples for Terraform guide ([#180](https://github.com/tydukes/coding-style-guide/pull/180))
+  * CI/CD pipeline examples (GitHub Actions, GitLab CI)
+  * Complete Terratest integration test suite
+  * Production modules: EKS, Monitoring, ECS, Lambda, DynamoDB
+  * 4,673 lines of deployment-ready code following best practices
+* CONTRACT.md template for IaC modules and roles
+* TESTING.md template for IaC projects
+* Code-to-text ratio analysis tool
 
 ### Changed
 
-- Multiple dependency updates
-  - Bumped actions/cache from 4 to 5 ([#177](https://github.com/tydukes/coding-style-guide/pull/177))
-  - Bumped actions/upload-artifact from 5 to 6 ([#178](https://github.com/tydukes/coding-style-guide/pull/178))
-  - Bumped actions/github-script from 7 to 8 ([#179](https://github.com/tydukes/coding-style-guide/pull/179))
-  - Bumped peter-evans/create-pull-request from 7 to 8 ([#176](https://github.com/tydukes/coding-style-guide/pull/176))
+* Multiple dependency updates
+  * Bumped actions/cache from 4 to 5 ([#177](https://github.com/tydukes/coding-style-guide/pull/177))
+  * Bumped actions/upload-artifact from 5 to 6 ([#178](https://github.com/tydukes/coding-style-guide/pull/178))
+  * Bumped actions/github-script from 7 to 8 ([#179](https://github.com/tydukes/coding-style-guide/pull/179))
+  * Bumped peter-evans/create-pull-request from 7 to 8 ([#176](https://github.com/tydukes/coding-style-guide/pull/176))
 
 ### Fixed
 
-- Removed all hardcoded version numbers from document footers
-- Updated changelog with versions 1.3.0 through 1.7.0
-- Navigation structure to include IaC templates
-- Broken anchor links in documentation
-- Metadata validation errors
+* Removed all hardcoded version numbers from document footers
+* Updated changelog with versions 1.3.0 through 1.7.0
+* Navigation structure to include IaC templates
+* Broken anchor links in documentation
+* Metadata validation errors
 
 ## Metrics
 
-- **Code-to-Text Ratio Achievement**: 18/19 guides now pass 3:1 target (94.7%)
-- **New Content**: ~13,867 lines of documentation and code examples
-- **Files Changed**: 54 files across documentation, templates, and tooling
+* **Code-to-Text Ratio Achievement**: 18/19 guides now pass 3:1 target (94.7%)
+* **New Content**: ~13,867 lines of documentation and code examples
+* **Files Changed**: 54 files across documentation, templates, and tooling
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.6.0...v1.7.0
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.6.0...v1.7.0>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.7.0)
 
@@ -334,29 +332,29 @@ The automated link checker flagged two 404s at `v1.8.0` due to a race condition 
 
 ### Added
 
-- Best Practices sections to 9 language guides ([#174](https://github.com/tydukes/coding-style-guide/pull/174))
-  - Python, TypeScript, Bash, PowerShell, SQL
-  - Terraform, Terragrunt, Ansible, Kubernetes
-  - Each section includes code organization, naming, error handling, performance
-- Comprehensive Common Pitfalls sections to all 19 language guides ([#163](https://github.com/tydukes/coding-style-guide/pull/163))
-  - Real-world examples of common mistakes
-  - Solutions and best practices for each pitfall
-  - Cross-referenced with anti-patterns sections
+* Best Practices sections to 9 language guides ([#174](https://github.com/tydukes/coding-style-guide/pull/174))
+  * Python, TypeScript, Bash, PowerShell, SQL
+  * Terraform, Terragrunt, Ansible, Kubernetes
+  * Each section includes code organization, naming, error handling, performance
+* Comprehensive Common Pitfalls sections to all 19 language guides ([#163](https://github.com/tydukes/coding-style-guide/pull/163))
+  * Real-world examples of common mistakes
+  * Solutions and best practices for each pitfall
+  * Cross-referenced with anti-patterns sections
 
 ### Fixed
 
-- Removed hardcoded dates, versions, and static metadata ([#173](https://github.com/tydukes/coding-style-guide/pull/173))
-  - Dynamic date generation for examples
-  - Version-agnostic documentation
-  - Improved maintainability
+* Removed hardcoded dates, versions, and static metadata ([#173](https://github.com/tydukes/coding-style-guide/pull/173))
+  * Dynamic date generation for examples
+  * Version-agnostic documentation
+  * Improved maintainability
 
 ### Changed
 
-- Configured Dependabot auto-merge for dependency updates ([#172](https://github.com/tydukes/coding-style-guide/pull/172))
-  - Automated patch and minor version updates
-  - Streamlined dependency management
+* Configured Dependabot auto-merge for dependency updates ([#172](https://github.com/tydukes/coding-style-guide/pull/172))
+  * Automated patch and minor version updates
+  * Streamlined dependency management
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.5.0...v1.6.0
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.5.0...v1.6.0>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.6.0)
 
@@ -366,25 +364,25 @@ The automated link checker flagged two 404s at `v1.8.0` due to a race condition 
 
 ### Added
 
-- Comprehensive Security Best Practices to all language guides ([#161](https://github.com/tydukes/coding-style-guide/pull/161))
-  - Input validation, authentication, encryption
-  - Secret management and secure coding practices
-  - Language-specific security patterns
-- Comprehensive Testing sections to all language guides ([#162](https://github.com/tydukes/coding-style-guide/pull/162))
-  - Unit testing, integration testing, test organization
-  - Testing frameworks and best practices
-  - CI/CD integration patterns
+* Comprehensive Security Best Practices to all language guides ([#161](https://github.com/tydukes/coding-style-guide/pull/161))
+  * Input validation, authentication, encryption
+  * Secret management and secure coding practices
+  * Language-specific security patterns
+* Comprehensive Testing sections to all language guides ([#162](https://github.com/tydukes/coding-style-guide/pull/162))
+  * Unit testing, integration testing, test organization
+  * Testing frameworks and best practices
+  * CI/CD integration patterns
 
 ### Changed
 
-- Multiple dependency updates
-  - Bumped actions/checkout from 4 to 6 ([#155](https://github.com/tydukes/coding-style-guide/pull/155))
-  - Bumped actions/github-script from 7 to 8 ([#156](https://github.com/tydukes/coding-style-guide/pull/156))
-  - Bumped peter-evans/create-pull-request from 6 to 7 ([#157](https://github.com/tydukes/coding-style-guide/pull/157))
-  - Bumped actions/setup-node from 4 to 6 ([#158](https://github.com/tydukes/coding-style-guide/pull/158))
-  - Bumped actions/upload-artifact from 4 to 5 ([#159](https://github.com/tydukes/coding-style-guide/pull/159))
+* Multiple dependency updates
+  * Bumped actions/checkout from 4 to 6 ([#155](https://github.com/tydukes/coding-style-guide/pull/155))
+  * Bumped actions/github-script from 7 to 8 ([#156](https://github.com/tydukes/coding-style-guide/pull/156))
+  * Bumped peter-evans/create-pull-request from 6 to 7 ([#157](https://github.com/tydukes/coding-style-guide/pull/157))
+  * Bumped actions/setup-node from 4 to 6 ([#158](https://github.com/tydukes/coding-style-guide/pull/158))
+  * Bumped actions/upload-artifact from 4 to 5 ([#159](https://github.com/tydukes/coding-style-guide/pull/159))
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.4.0...v1.5.0
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.4.0...v1.5.0>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.5.0)
 
@@ -394,25 +392,25 @@ The automated link checker flagged two 404s at `v1.8.0` due to a race condition 
 
 ### Added
 
-- Anti-patterns sections to all 19 language guides
-  - Initial 9 language guides ([#152](https://github.com/tydukes/coding-style-guide/pull/152))
-  - Remaining 9 language guides ([#153](https://github.com/tydukes/coding-style-guide/pull/153))
-  - Real-world examples of code to avoid
-- Code block language tag standards ([#151](https://github.com/tydukes/coding-style-guide/pull/151))
-  - Standardized syntax highlighting tags
-  - Improved documentation consistency
-- Documentation heading structure standards ([#150](https://github.com/tydukes/coding-style-guide/pull/150))
-  - Consistent heading hierarchy
-  - Improved navigation and readability
+* Anti-patterns sections to all 19 language guides
+  * Initial 9 language guides ([#152](https://github.com/tydukes/coding-style-guide/pull/152))
+  * Remaining 9 language guides ([#153](https://github.com/tydukes/coding-style-guide/pull/153))
+  * Real-world examples of code to avoid
+* Code block language tag standards ([#151](https://github.com/tydukes/coding-style-guide/pull/151))
+  * Standardized syntax highlighting tags
+  * Improved documentation consistency
+* Documentation heading structure standards ([#150](https://github.com/tydukes/coding-style-guide/pull/150))
+  * Consistent heading hierarchy
+  * Improved navigation and readability
 
 ### Fixed
 
-- Standardized heading structure across all documentation ([#160](https://github.com/tydukes/coding-style-guide/pull/160))
-  - Removed duplicate H1 headings
-  - Fixed heading hierarchy issues
-- Resolved broken links and updated link-check exclusions ([#154](https://github.com/tydukes/coding-style-guide/pull/154))
+* Standardized heading structure across all documentation ([#160](https://github.com/tydukes/coding-style-guide/pull/160))
+  * Removed duplicate H1 headings
+  * Fixed heading hierarchy issues
+* Resolved broken links and updated link-check exclusions ([#154](https://github.com/tydukes/coding-style-guide/pull/154))
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.3.0...v1.4.0
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.3.0...v1.4.0>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.4.0)
 
@@ -422,22 +420,22 @@ The automated link checker flagged two 404s at `v1.8.0` due to a race condition 
 
 ### Added
 
-- Comprehensive migration guides
-  - PEP 8 migration guide ([#147](https://github.com/tydukes/coding-style-guide/pull/147))
-  - Google Python Style Guide migration guide ([#148](https://github.com/tydukes/coding-style-guide/pull/148))
-  - Airbnb Style Guide migration guide ([#149](https://github.com/tydukes/coding-style-guide/pull/149))
-- Visual repository structure diagrams ([#146](https://github.com/tydukes/coding-style-guide/pull/146))
-  - Mermaid diagrams for GitFlow, CI/CD, and Metadata Flow ([#145](https://github.com/tydukes/coding-style-guide/pull/145))
-- Comprehensive refactoring examples directory ([#144](https://github.com/tydukes/coding-style-guide/pull/144))
-  - Before/after examples for common refactoring patterns
-- Quick Reference tables to all 19 language guides ([#141](https://github.com/tydukes/coding-style-guide/pull/141))
-  - At-a-glance syntax and best practices
+* Comprehensive migration guides
+  * PEP 8 migration guide ([#147](https://github.com/tydukes/coding-style-guide/pull/147))
+  * Google Python Style Guide migration guide ([#148](https://github.com/tydukes/coding-style-guide/pull/148))
+  * Airbnb Style Guide migration guide ([#149](https://github.com/tydukes/coding-style-guide/pull/149))
+* Visual repository structure diagrams ([#146](https://github.com/tydukes/coding-style-guide/pull/146))
+  * Mermaid diagrams for GitFlow, CI/CD, and Metadata Flow ([#145](https://github.com/tydukes/coding-style-guide/pull/145))
+* Comprehensive refactoring examples directory ([#144](https://github.com/tydukes/coding-style-guide/pull/144))
+  * Before/after examples for common refactoring patterns
+* Quick Reference tables to all 19 language guides ([#141](https://github.com/tydukes/coding-style-guide/pull/141))
+  * At-a-glance syntax and best practices
 
 ### Fixed
 
-- Resolved broken links in documentation ([#142](https://github.com/tydukes/coding-style-guide/pull/142))
+* Resolved broken links in documentation ([#142](https://github.com/tydukes/coding-style-guide/pull/142))
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.2.1...v1.3.0
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.2.1...v1.3.0>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.3.0)
 
@@ -448,21 +446,21 @@ The automated link checker flagged two 404s at `v1.8.0` due to a race condition 
 This release adds comprehensive repository documentation and community files to improve project discoverability and contributor experience.
 
 ### Added
-- MIT License for open source distribution
-- Contributing guidelines (CONTRIBUTING.md)
-- Code of Conduct (CODE_OF_CONDUCT.md) - Contributor Covenant v2.1
-- Security policy (SECURITY.md)
-- AI assistant guide (CLAUDE.md)
-- Pull request template
-- Issue templates (bug report, feature request, documentation)
-- Dependabot configuration for automated dependency updates
-- Comprehensive README badges
+* MIT License for open source distribution
+* Contributing guidelines (CONTRIBUTING.md)
+* Code of Conduct (CODE_OF_CONDUCT.md) - Contributor Covenant v2.1
+* Security policy (SECURITY.md)
+* AI assistant guide (CLAUDE.md)
+* Pull request template
+* Issue templates (bug report, feature request, documentation)
+* Dependabot configuration for automated dependency updates
+* Comprehensive README badges
 
 ### Files Changed
-- 13 files added
-- 1,124 lines inserted
+* 13 files added
+* 1,124 lines inserted
 
-**Full Changelog**: https://github.com/tydukes/coding-style-guide/compare/v1.1.0...v1.2.0
+**Full Changelog**: <https://github.com/tydukes/coding-style-guide/compare/v1.1.0...v1.2.0>
 
 [View Release](https://github.com/tydukes/coding-style-guide/releases/tag/v1.2.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coding-style-guide"
-version = "1.8.17"
+version = "1.8.18"
 description = "Comprehensive coding style guide and best practices documentation"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

- Creates `docs/11_cloud_providers/aws.md` with the foundational six sections
- Fixes two pre-existing MD036 markdownlint violations in `changelog.md`
- Bumps version to `1.8.18`

## Context

Closes #394. Part of the AWS cloud provider guide series tracked in #393.

The page is **intentionally excluded from `mkdocs.yml` nav** until the full guide is complete. It will be added in the final issue (#398).

## Sections included

| Section | Content |
|---|---|
| Overview | Key characteristics, global footprint, compliance certifications |
| Quick Reference | Naming format, tagging, Terraform provider version, auth, secrets per-resource |
| Account Hierarchy | Organizations, OU structure, landing zone accounts (log-archive, audit, network, workload), SCPs (deny root, deny leave org, deny disable security services), cross-account role assumption |
| Resource Naming | Naming locals module with region short codes, S3 uniqueness rules with `null_resource` precondition validation, IAM global naming (no region), usage example |
| Tagging Standards | `provider default_tags` block, AWS Config `REQUIRED_TAGS` rule, SCP deny-on-create without tags, AWS Tag Policies for Environment and ManagedBy, `local.common_tags` pattern |

## Test plan

- [ ] `uv run mkdocs build --strict` passes
- [ ] `pre-commit run --all-files` passes
- [ ] Verify `aws.md` does NOT yet appear in site nav (expected — added in #398)

🤖 Generated with [Claude Code](https://claude.com/claude-code)