### PR TITLE
docs(aws): add compute and data services sections

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,12 @@ This changelog is automatically generated from GitHub releases. Each release inc
 
 Changes that are in the main branch but not yet released.
 
+## [v1.8.21] - 2026-02-22
+
+### Added
+
+- AWS Cloud Provider Guide: Compute and Data Services sections covering EKS (managed node groups, IRSA, add-ons, OIDC provider), ECS/Fargate (awsvpc networking, Secrets Manager injection), Lambda (reserved concurrency, VPC attachment, DLQ), EC2 (IMDSv2, launch templates, ASGs), RDS/Aurora (Multi-AZ, managed master passwords, serverless v2), S3 (public access block, versioning, SSE-KMS, lifecycle, TLS policy, Object Lock), ElastiCache Redis (replication group, in-transit encryption, auth token rotation), and ECR (immutable tags, scan on push, lifecycle policies, cross-account pull) closes #397
+
 ## [v1.8.20] - 2026-02-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coding-style-guide"
-version = "1.8.20"
+version = "1.8.21"
 description = "Comprehensive coding style guide and best practices documentation"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Adds the Compute Services and Data Services sections to `docs/11_cloud_providers/aws.md`, covering the full application stack that sits on top of the networking foundation from #401.

## Compute Services

- **Amazon EKS** — managed node groups with IMDSv2 launch template, IRSA/OIDC provider, CoreDNS/kube-proxy/VPC CNI/EBS CSI add-ons with prefix delegation
- **ECS/Fargate** — `awsvpc` networking, Secrets Manager injection (no plaintext env vars), deployment circuit breaker with rollback, Container Insights
- **AWS Lambda** — reserved concurrency, VPC attachment, DLQ, async destinations, X-Ray tracing
- **Amazon EC2** — IMDSv2 required (hop limit 1), launch templates, ASGs with rolling instance refresh, AL2023 AMI lookup

## Data Services

- **RDS/Aurora** — Multi-AZ, managed master user password (KMS), Performance Insights, Aurora Serverless v2 with writer+reader in prod
- **Amazon S3** — public access block, versioning, SSE-KMS with bucket key, lifecycle tiering (IA → Glacier IR), TLS-only bucket policy, Object Lock for compliance
- **ElastiCache Redis** — replication group, in-transit encryption (required mode), auth token with rotation, slow-log and engine-log delivery to CloudWatch
- **Amazon ECR** — immutable tags, KMS encryption, scan on push, lifecycle policies (untagged + tagged count), cross-account pull resource policy

Closes #397
Part of #393

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [x] All pre-commit hooks pass
- [x] `aws.md` still excluded from nav (added in #398)

🤖 Generated with [Claude Code](https://claude.com/claude-code)