### PR TITLE
docs(aws): add observability, CI/CD, state, cost, Terragrunt, and nav

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,12 @@ This changelog is automatically generated from GitHub releases. Each release inc
 
 Changes that are in the main branch but not yet released.
 
+## [v1.8.22] - 2026-02-22
+
+### Added
+
+- AWS Cloud Provider Guide: Monitoring and Observability (CloudWatch metric and composite alarms, log metric filters, X-Ray groups and sampling rules), CI/CD Integration (GitHub Actions OIDC with plan/apply role separation, Terraform workflow with PR plan comments), Terraform State Management (S3 backend with DynamoDB locking, MFA delete policy, cross-stack remote state), Cost Optimization (AWS Budgets, Cost Anomaly Detection, Spot mixed-instance ASG), Terragrunt Patterns (root configuration, remote state generation, provider generation, dependency blocks), and References section; adds aws.md to mkdocs.yml nav closes #398 closes #393
+
 ## [v1.8.21] - 2026-02-22
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,7 @@ nav:
       - From Google Style Guide: 10_migration_guides/from_google.md
       - From Airbnb Style Guide: 10_migration_guides/from_airbnb.md
   - Cloud Providers:
+      - Amazon Web Services: 11_cloud_providers/aws.md
       - Microsoft Azure: 11_cloud_providers/azure.md
       - Google Cloud Platform: 11_cloud_providers/gcp.md
   - CI / CD:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coding-style-guide"
-version = "1.8.21"
+version = "1.8.22"
 description = "Comprehensive coding style guide and best practices documentation"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Summary

Completes the AWS Cloud Provider Guide — the final issue in the #393 tracking series. Adds all remaining sections and integrates `aws.md` into the site navigation.

## New Sections

### Monitoring and Observability
- CloudWatch metric alarms with `datapoints_to_alarm` (2-of-3 pattern)
- Composite alarm to reduce pager noise (CPU AND memory must both be high)
- KMS-encrypted SNS topic, CloudWatch dashboard with ECS and ALB widgets
- Log metric filter extracting 5xx errors with derived alarm
- X-Ray group with Insights enabled, sampling rule (5% + reservoir)

### CI/CD Integration
- GitHub Actions OIDC: separate IAM roles for plan (any branch) and apply (main only)
- Terraform workflow: init → validate → plan → post plan to PR → apply with `environment: production` gate
- No long-lived credentials — pure OIDC token exchange

### Terraform State Management
- S3 backend with DynamoDB locking, KMS encryption, bucket key
- Bucket policy: deny HTTP + deny delete without MFA
- Per-environment `backend.tf` example
- Cross-stack `terraform_remote_state` data source pattern

### Cost Optimization
- `aws_budgets_budget` with 80% forecasted + 100% actual notifications
- `aws_ce_anomaly_monitor` + `aws_ce_anomaly_subscription` for spike detection
- Mixed-instance ASG: 2 on-demand base + Spot scale-out with `price-capacity-optimized`

### Terragrunt Patterns
- Root `terragrunt.hcl`: `remote_state` and `generate "provider"` with cross-account role assumption
- `account.hcl` / `region.hcl` / `org.hcl` hierarchy
- Module `terragrunt.hcl` with `dependency` blocks and `mock_outputs`
- `run-all apply/plan/destroy` commands

### References
- AWS Well-Architected, Security, Organizations, IAM, VPC, EKS Best Practices docs
- Cross-links to terraform.md, terragrunt.md, cloudformation.md, cdk.md, kubernetes.md, gitops.md, github_actions.md, azure.md, gcp.md

## Nav Integration

Added `Amazon Web Services: 11_cloud_providers/aws.md` to `mkdocs.yml` (alphabetically first under Cloud Providers).

Closes #398
Closes #393

## Test plan

- [x] `uv run mkdocs build --strict` passes — aws.md no longer listed as excluded from nav
- [x] `uv run python scripts/analyze_code_ratio.py` — 35/35 language guides still pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)