### PR TITLE
fix(docs): replace var with const in shortcuts.js

### DIFF
--- a/docs/javascripts/shortcuts.js
+++ b/docs/javascripts/shortcuts.js
@@ -1,7 +1,7 @@
 document.addEventListener("keydown", function (e) {
   if ((e.metaKey || e.ctrlKey) && e.key === "k") {
     e.preventDefault();
-    var search = document.querySelector(".md-search__input");
+    const search = document.querySelector(".md-search__input");
     if (search) {
       search.focus();
       search.select();


### PR DESCRIPTION
## Summary

- Replaces `var search` with `const search` in `docs/javascripts/shortcuts.js`

## SonarCloud

Resolves **1 CRITICAL** S3504 issue on `main`.

Closes #409

## Test plan

- [ ] Verify `docs/javascripts/shortcuts.js` no longer uses `var`
- [ ] Confirm MkDocs build passes (CI)
- [ ] SonarCloud shows issue resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)