### PR TITLE
fix(cli): resolve 15 TypeScript SonarCloud issues

### DIFF
--- a/cli/src/config/loader.test.ts
+++ b/cli/src/config/loader.test.ts
@@ -5,9 +5,9 @@
 
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import type { StyleGuideConfig, Language, LanguageConfig } from "../types.js";
 
 function mergeConfig(
@@ -30,11 +30,11 @@ function mergeConfig(
           ...langConfig,
           linters: {
             ...defaultLang.linters,
-            ...(langConfig as LanguageConfig).linters,
+            ...langConfig.linters,
           },
         };
       } else if (langConfig) {
-        merged.languages[lang as Language] = langConfig as LanguageConfig;
+        merged.languages[lang as Language] = langConfig;
       }
     }
   }

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -5,7 +5,7 @@
  * @author Tyler Dukes
  */
 
-import { createRequire } from "module";
+import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json") as { version: string };
 export const VERSION: string = pkg.version;


### PR DESCRIPTION
## Summary

- **S7772** — add `node:` prefix to all bare Node built-in imports (`module`, `fs`, `path`, `os`, `child_process`)
- **S7773** — replace global `parseInt`/`isNaN` with `Number.parseInt`/`Number.isNaN`
- **S4325** — remove two redundant `as LanguageConfig` casts already narrowed by if-guards
- **S3358** — extract `toSeverity()` helper to eliminate nested ternary in `parseShellcheckOutput`

## Files changed

| File | Changes |
|------|---------|
| `cli/src/version.ts` | `"module"` → `"node:module"` |
| `cli/src/config/loader.test.ts` | `node:` prefixes for `fs`, `path`, `os`; remove 2 unnecessary casts |
| `cli/src/linters/registry.test.ts` | `node:child_process`; `Number.parseInt`/`Number.isNaN`; `toSeverity()` helper |

Closes #408

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm test` — 57/57 pass
- [ ] SonarCloud shows all 15 issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)