### PR TITLE
fix(docs): update SLSA provenance link to canonical URL

### DIFF
--- a/docs/05_ci_cd/code_signing_guide.md
+++ b/docs/05_ci_cd/code_signing_guide.md
@@ -1592,7 +1592,7 @@ EOF
 - [GPG Documentation](https://gnupg.org/documentation/)
 - [Sigstore Documentation](https://docs.sigstore.dev/)
 - [Cosign GitHub Repository](https://github.com/sigstore/cosign)
-- [SLSA Provenance Specification](https://slsa.dev/provenance/)
+- [SLSA Provenance Specification](https://slsa.dev/spec/v1.2/provenance)
 - [in-toto Attestation Framework](https://in-toto.io/)
 
 ### Tools and Utilities


### PR DESCRIPTION
## Summary

- Updates `https://slsa.dev/provenance/` → `https://slsa.dev/spec/v1.2/provenance` in `docs/05_ci_cd/code_signing_guide.md`

## Root cause

The old URL redirected twice (`/provenance/` → `/spec/latest/provenance` → `/spec/v1.2/provenance`), causing an `ECONNRESET` in the automated link checker and triggering issue #415. The canonical URL resolves directly with HTTP 200.

Closes #415

## Test plan

- [ ] `curl -sIL https://slsa.dev/spec/v1.2/provenance` returns 200
- [ ] Link checker passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)