### PR TITLE
fix(release): fall back to github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.AUTO_MERGE_TOKEN }}
+          token: ${{ secrets.AUTO_MERGE_TOKEN || github.token }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

- Falls back to the workflow `GITHUB_TOKEN` when `AUTO_MERGE_TOKEN` is not configured.
- Unblocks the manual release workflow checkout step so version bumping and npm publishing can proceed.

## Validation

- [x] `git diff --check`
- [x] pre-commit hooks run by commit

## Context

The post-merge release run failed during `actions/checkout` because the configured `AUTO_MERGE_TOKEN` credential was unavailable or empty, causing GitHub checkout to fetch over unauthenticated HTTPS.