### PR TITLE
fix(release): use default checkout token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.AUTO_MERGE_TOKEN || github.token }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

- Removes the explicit `AUTO_MERGE_TOKEN` checkout override from the release workflow.
- Lets `actions/checkout` use the job-scoped `GITHUB_TOKEN`, which already has `contents: write` in this job.

## Context

The previous fallback still failed because `AUTO_MERGE_TOKEN` appears to be present but unusable, so the expression selected the bad credential instead of the default workflow token.

## Validation

- [x] `git diff --check`
- [x] pre-commit hooks run by commit