### PR TITLE
[codex] Harden release publishing automation

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,6 @@
 name: Auto-Merge
 
-on:
+"on":
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -8,12 +8,14 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Only run if CI workflow completed successfully
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
+      issues: write
 
     steps:
       - name: Get PR number
@@ -21,26 +23,25 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            // Get PR from the workflow run branch
+            const run = context.payload.workflow_run;
+
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              head: `${context.repo.owner}:${context.payload.workflow_run.head_branch}`
+              head: `${context.repo.owner}:${run.head_branch}`
             });
 
             if (pullRequests.length === 0) {
-              console.log('No open PR found for this branch');
-              core.setFailed('No PR found for branch');
-              return null;
+              core.notice(`No open same-repository PR found for ${run.head_branch}`);
+              return;
             }
 
             const prNumber = pullRequests[0].number;
-            console.log(`Found PR #${prNumber} for branch ${context.payload.workflow_run.head_branch}`);
+            console.log(`Found PR #${prNumber} for branch ${run.head_branch}`);
             core.setOutput('number', prNumber);
-            return prNumber;
 
-      - name: Get PR details and check author
+      - name: Check auto-merge eligibility
         id: pr-details
         if: steps.pr-number.outputs.number != ''
         uses: actions/github-script@v9
@@ -55,92 +56,98 @@ jobs:
             });
 
             const author = pr.user.login;
-            const isAllowed = author === 'dependabot[bot]' || author === 'tydukes';
+            const trustedAutomation = ['dependabot[bot]'];
+            const trustedMaintainers = ['tydukes'];
+            const isAllowed = trustedAutomation.includes(author) || trustedMaintainers.includes(author);
+            const sameRepository = pr.head.repo.full_name === pr.base.repo.full_name;
 
             console.log(`PR #${prNumber} by ${author}`);
+            console.log(`Same repository branch: ${sameRepository}`);
             console.log(`Auto-merge allowed: ${isAllowed}`);
 
             if (!isAllowed) {
-              core.setFailed(`Auto-merge not allowed for user: ${author}`);
+              core.notice(`Auto-merge skipped for untrusted author: ${author}`);
+              return;
+            }
+
+            if (!sameRepository) {
+              core.notice(`Auto-merge skipped for forked PR #${prNumber}`);
               return;
             }
 
             core.setOutput('author', author);
             core.setOutput('pr_number', prNumber);
 
-      - name: Auto-approve PR
+      - name: Enable auto-merge
         if: steps.pr-details.outputs.pr_number != ''
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.pr-details.outputs.pr_number }};
-            const author = '${{ steps.pr-details.outputs.author }}';
-            const approvalBody = author === 'dependabot[bot]'
-              ? '✅ Auto-approved by workflow: All checks passed for Dependabot PR'
-              : '✅ Auto-approved by workflow: All checks passed';
-
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-              event: 'APPROVE',
-              body: approvalBody
-            });
-
-            console.log(`✅ Approved PR #${prNumber}`);
-
-      - name: Merge PR
-        if: steps.pr-details.outputs.pr_number != ''
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}
-          script: |
-            const prNumber = ${{ steps.pr-details.outputs.pr_number }};
-
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber
             });
 
-            try {
-              await github.rest.pulls.merge({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                merge_method: 'squash',
-                commit_title: pr.title,
-                commit_message: `${pr.body || ''}\n\n🤖 Auto-merged after successful checks`
-              });
+            const query = `
+              mutation EnablePullRequestAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: $mergeMethod
+                }) {
+                  pullRequest {
+                    number
+                    autoMergeRequest {
+                      enabledAt
+                    }
+                  }
+                }
+              }
+            `;
 
-              console.log(`✅ PR #${prNumber} auto-merged successfully`);
+            try {
+              await github.graphql(query, {
+                pullRequestId: pr.node_id,
+                mergeMethod: 'SQUASH'
+              });
+              console.log(`Enabled auto-merge for PR #${prNumber}`);
             } catch (error) {
-              console.error('Merge failed:', error.message);
-              throw error;
+              if (error.message.includes('Pull request Auto-merge is already enabled')) {
+                console.log(`Auto-merge already enabled for PR #${prNumber}`);
+                return;
+              }
+
+              core.setFailed(`Unable to enable auto-merge for PR #${prNumber}: ${error.message}`);
             }
 
-      - name: Delete branch after merge
+      - name: Add policy note
         if: steps.pr-details.outputs.pr_number != ''
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}
           script: |
             const prNumber = ${{ steps.pr-details.outputs.pr_number }};
+            const marker = '<!-- auto-merge-policy-note -->';
+            const body = [
+              marker,
+              'Auto-merge was enabled by policy for trusted authors.',
+              'GitHub branch protection and required checks still control when this PR can merge.'
+            ].join('\n');
 
-            const { data: pr } = await github.rest.pulls.get({
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: prNumber
+              issue_number: prNumber,
+              per_page: 100
             });
 
-            try {
-              await github.rest.git.deleteRef({
+            const existing = comments.find((comment) => comment.body.includes(marker));
+
+            if (!existing) {
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: `heads/${pr.head.ref}`
+                issue_number: prNumber,
+                body
               });
-              console.log(`✅ Deleted branch: ${pr.head.ref}`);
-            } catch (error) {
-              console.log('Branch already deleted or error:', error.message);
             }

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,8 +2,9 @@ name: Build and Publish Container
 
 "on":
   push:
-    branches: [main]
     tags: ['v*']
+  release:
+    types: [published]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -15,10 +16,14 @@ env:
 permissions:
   contents: read
   packages: write
+  issues: write
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    concurrency:
+      group: container-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository
@@ -41,12 +46,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name != 'pull_request' }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -93,3 +97,73 @@ jobs:
           name: sbom
           path: sbom.spdx.json
           retention-days: 30
+
+  create-recovery-issue:
+    name: Create Container Recovery Issue
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: always() && needs.build-and-push.result == 'failure' && github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create or update recovery issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const refName = context.ref.replace('refs/tags/', '').replace('refs/heads/', '');
+            const runUrl = [
+              context.serverUrl,
+              context.repo.owner,
+              context.repo.repo,
+              'actions',
+              'runs',
+              context.runId
+            ].join('/');
+            const title = `Container publishing recovery required for ${refName}`;
+            const body = `## Container Publishing Recovery
+
+            Container publishing failed for a trusted release or tag event.
+
+            - **Ref**: ${context.ref}
+            - **Workflow run**: ${runUrl}
+            - **Commit**: ${context.sha}
+
+            ## Recommended Forward-Fix Path
+
+            1. Inspect the failed container build or push logs.
+            2. Check whether any expected image tags already exist in GHCR.
+            3. Fix the issue on main without changing the intended release version.
+            4. Re-run this workflow for ${refName} or publish only the missing image tags.
+
+            ---
+            This issue was created automatically by the container workflow.`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'scope:automation,type:maintenance',
+              per_page: 100
+            });
+
+            const existing = issues.find((issue) => issue.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body
+              });
+              console.log(`Updated container recovery issue #${existing.number}`);
+            } else {
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['scope:automation', 'type:maintenance', 'priority:high']
+              });
+              console.log(`Created container recovery issue #${issue.data.number}`);
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Automated Release
 
-on:
+"on":
   workflow_dispatch:
     inputs:
       bump_type:
@@ -13,10 +13,41 @@ on:
           - minor
           - patch
         default: auto
+      release_version:
+        description: 'Exact version to release for partial-release recovery (for example, 1.2.3)'
+        required: false
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
+  preflight:
+    name: Release Preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate trusted release ref
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::Releases must be dispatched from the main branch. Current ref: ${GITHUB_REF}"
+            exit 1
+          fi
+
+      - name: Validate required publish token
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::error::NPM_TOKEN is required because npm publishing is part of the release path."
+            exit 1
+          fi
+
   determine-version:
     name: Determine Next Version
+    needs: preflight
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,9 +100,19 @@ jobs:
         run: |
           CURRENT="${{ steps.current.outputs.version }}"
           INPUT_BUMP="${{ github.event.inputs.bump_type }}"
+          INPUT_VERSION="${{ github.event.inputs.release_version }}"
           AUTO_BUMP="${{ steps.analyze.outputs.bump_type }}"
 
-          # Use manual override if provided and not 'auto'
+          if [ -n "$INPUT_VERSION" ]; then
+            if ! echo "$INPUT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+              echo "::error::release_version must be a semantic version without the leading v."
+              exit 1
+            fi
+            echo "new_version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+            echo "Using explicit recovery version: $INPUT_VERSION"
+            exit 0
+          fi
+
           if [ "$INPUT_BUMP" != "auto" ] && [ -n "$INPUT_BUMP" ]; then
             BUMP_TYPE="$INPUT_BUMP"
             echo "Using manual bump type: $BUMP_TYPE"
@@ -111,6 +152,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -140,8 +182,12 @@ jobs:
           NEW_VERSION: ${{ needs.determine-version.outputs.new_version }}
         run: |
           git add pyproject.toml cli/package.json cli/package-lock.json
-          git commit -m "chore(release): bump version to ${NEW_VERSION}"
-          git push
+          if git diff --cached --quiet; then
+            echo "Version files already match v${NEW_VERSION}; continuing recovery path."
+          else
+            git commit -m "chore(release): bump version to ${NEW_VERSION}"
+            git push origin HEAD:main
+          fi
 
       - name: Create GitHub Release
         id: create_release
@@ -149,7 +195,13 @@ jobs:
           NEW_VERSION: ${{ needs.determine-version.outputs.new_version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if gh release view "v${NEW_VERSION}" >/dev/null 2>&1; then
+            echo "Release v${NEW_VERSION} already exists; continuing recovery path."
+            exit 0
+          fi
+
           gh release create "v${NEW_VERSION}" \
+            --target main \
             --title "v${NEW_VERSION}" \
             --generate-notes
           echo "Created release v${NEW_VERSION}"
@@ -183,7 +235,7 @@ jobs:
           else
             git add docs/changelog.md
             git commit -m "docs(changelog): update changelog for v${NEW_VERSION}"
-            git push
+            git push origin HEAD:main
           fi
 
       - name: Summary
@@ -204,6 +256,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -215,7 +268,132 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Verify package version
+        env:
+          NEW_VERSION: ${{ needs.determine-version.outputs.new_version }}
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./cli/package.json').version")
+          if [ "${PACKAGE_VERSION}" != "${NEW_VERSION}" ]; then
+            echo "::error::cli/package.json version ${PACKAGE_VERSION} does not match release ${NEW_VERSION}."
+            exit 1
+          fi
+
+      - name: Check npm publish state
+        id: npm-state
+        env:
+          NEW_VERSION: ${{ needs.determine-version.outputs.new_version }}
+        run: |
+          PACKAGE_NAME=$(node -p "require('./cli/package.json').name")
+          if npm view "${PACKAGE_NAME}@${NEW_VERSION}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "${PACKAGE_NAME}@${NEW_VERSION} is already published; skipping npm publish."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and publish
-        run: cd cli && npm ci && npm run build && npm publish --access public
+        if: steps.npm-state.outputs.published != 'true'
+        run: cd cli && npm ci && npm run build && npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release-recovery:
+    name: Create Release Recovery Issue
+    needs: [preflight, determine-version, update-version, publish-cli]
+    runs-on: ubuntu-latest
+    if: always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/main'
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Create or update recovery issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const version = '${{ needs.determine-version.outputs.new_version }}' || 'unknown';
+            const runUrl = [
+              context.serverUrl,
+              context.repo.owner,
+              context.repo.repo,
+              'actions',
+              'runs',
+              context.runId
+            ].join('/');
+            const results = {
+              preflight: '${{ needs.preflight.result }}',
+              determineVersion: '${{ needs.determine-version.result }}',
+              updateVersionAndRelease: '${{ needs.update-version.result }}',
+              publishCli: '${{ needs.publish-cli.result }}'
+            };
+
+            const completed = Object.entries(results)
+              .filter(([, result]) => result === 'success')
+              .map(([name]) => `- ${name}`)
+              .join('\n') || '- None';
+
+            const failed = Object.entries(results)
+              .filter(([, result]) => ['failure', 'cancelled'].includes(result))
+              .map(([name, result]) => `- ${name}: ${result}`)
+              .join('\n') || '- None';
+
+            const title = version === 'unknown'
+              ? 'Release recovery required'
+              : `Release recovery required for v${version}`;
+
+            const body = `## Release Recovery
+
+            A release workflow partially failed and needs fix-forward recovery.
+
+            - **Version**: ${version}
+            - **Workflow run**: ${runUrl}
+            - **Triggered from**: ${context.ref}
+            - **Commit**: ${context.sha}
+
+            ## Completed Steps
+
+            ${completed}
+
+            ## Failed Steps
+
+            ${failed}
+
+            ## Recommended Forward-Fix Path
+
+            1. Inspect the failed job logs in the workflow run.
+            2. Check whether v${version} exists as a GitHub release, npm package, or container image.
+            3. Do not trigger a new version unless no artifacts were published.
+            4. Fix the failing automation or package state on main.
+            5. Re-run the release workflow with \`release_version=${version}\` to complete the same version.
+            6. Manually publish only the missing artifact if a full rerun would duplicate completed work.
+
+            ---
+            This issue was created automatically by the release workflow.`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'scope:automation,type:maintenance',
+              per_page: 100
+            });
+
+            const existing = issues.find((issue) => issue.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body
+              });
+              console.log(`Updated release recovery issue #${existing.number}`);
+            } else {
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['scope:automation', 'type:maintenance', 'priority:high']
+              });
+              console.log(`Created release recovery issue #${issue.data.number}`);
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.AUTO_MERGE_TOKEN || github.token }}
 
       - name: Configure git
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,16 @@ gh workflow run release.yml --field bump_type=patch
 gh workflow run release.yml --field bump_type=auto
 ```
 
-The workflow automatically: bumps `pyproject.toml`, creates a GitHub release, generates
-`docs/changelog.md` via the GitHub API, and commits the changelog. **Never edit
-`docs/changelog.md` manually.**
+The workflow automatically: bumps `pyproject.toml` and `cli/package.json`, generates
+`docs/changelog.md` via the GitHub API, creates a GitHub release, and publishes the CLI package to
+npm. **Never edit `docs/changelog.md` manually.**
+
+Release publishing must run from `main`. If a partial release needs recovery, rerun the workflow with
+the exact version instead of creating a new version:
+
+```bash
+gh workflow run release.yml --ref main --field release_version=1.2.3
+```
 
 ### 3. GitHub Actions Version Constraint
 
@@ -148,8 +155,8 @@ testable and map directly to test descriptions:
 Stage 1: Pre-commit hooks  (<30s)  formatting, linting, secret detection
 Stage 2: CI pipeline       (<10m)  metadata validation (warn), linting (block), docs build
 Stage 3: Quality gates     (<10m)  spell-check (BLOCKS merge), link-check
-Stage 4: Deployment        (<5m)   GitHub Pages, container publish
-Stage 5: Auto-merge        (auto)  squash-merge for dependabot[bot] and tydukes
+Stage 4: Deployment        (<5m)   GitHub Pages, release/tag container publish
+Stage 5: Auto-merge        (auto)  enable squash auto-merge for dependabot[bot] and tydukes
 ```
 
 **Spell checker blocks merges.** New technical terms must be whitelisted in `.github/cspell.json`
@@ -202,7 +209,10 @@ Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, 
 
 ## CI/CD Automation Notes
 
-**Auto-merge**: PRs from `dependabot[bot]` or `tydukes` squash-merge automatically after CI.
+**Auto-merge**: same-repository PRs from `dependabot[bot]` or `tydukes` can have GitHub
+auto-merge enabled after CI succeeds. The workflow uses `GITHUB_TOKEN`; it does not auto-approve,
+directly merge, use `AUTO_MERGE_TOKEN`, or bypass branch protection. Outside-contributor PRs must
+receive normal maintainer review and required checks before merge.
 
 **Blocking checks** (prevent merge):
 
@@ -219,6 +229,10 @@ Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, 
 action version: edit `versions.yml`, manually update all workflow files to match, then CI
 validates they stay in sync.
 
+**Token policy**: use `GITHUB_TOKEN` for checkout, version bump commits, changelog commits, release
+creation, auto-merge enablement, recovery issue creation, and container publishing to `ghcr.io`. Add a PAT
+only when GitHub permission limits require it, and document the exact reason, scopes, and expiration.
+
 ---
 
 ## Container Usage
@@ -232,7 +246,8 @@ docker run --rm ghcr.io/tydukes/coding-style-guide:latest help
 ```
 
 Multi-platform builds (linux/amd64, linux/arm64) publish to `ghcr.io/tydukes/coding-style-guide`
-on every push to main.
+from release or `v*` tag events. Pull requests build a single-platform image for validation without
+pushing.
 
 ---
 

--- a/docs/05_ci_cd/dependabot_auto_merge.md
+++ b/docs/05_ci_cd/dependabot_auto_merge.md
@@ -11,14 +11,15 @@ search_keywords: [dependabot, auto merge, dependency updates, github, automation
 
 ## Overview
 
-This guide explains the Dependabot auto-merge configuration for this repository, enabling automatic
-merging of dependency updates when all CI checks pass.
+This guide explains the Dependabot auto-merge configuration for this repository. The workflow enables
+GitHub auto-merge for trusted same-repository pull requests after CI succeeds, while branch
+protection and required checks still decide when the pull request can merge.
 
 ### What This Configuration Provides
 
 - ✅ **Automated Dependency Updates**: Weekly checks for Python, GitHub Actions, and Docker updates
-- ✅ **Auto-Merge for Safe Updates**: Automatic merging of patch/minor updates after checks pass
-- ✅ **Maintainer Auto-Merge**: Auto-merge support for repository maintainer PRs
+- ✅ **Auto-Merge for Safe Updates**: GitHub auto-merge enablement for patch/minor updates
+- ✅ **Maintainer Auto-Merge**: Auto-merge enablement for trusted maintainer PRs
 - ✅ **Grouped Updates**: Related dependencies updated together to reduce PR noise
 - ✅ **Security-First**: All security checks must pass before auto-merge
 
@@ -78,127 +79,47 @@ Located at `.github/workflows/auto-merge.yml`:
 name: Auto-Merge
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted]
-  check_suite:
+  workflow_run:
+    workflows: ["CI"]
     types: [completed]
-  status: {}
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      github.event.pull_request.user.login == 'tydukes'
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
+      issues: write
 
     steps:
-      - name: Wait for status checks
-        # Ensures all CI checks pass before merge
-
-      - name: Auto-approve PR
-        # Automatically approves PR using AUTO_MERGE_TOKEN
-        # Works for both Dependabot and maintainer PRs
+      - name: Check auto-merge eligibility
+        # Allows dependabot[bot] and tydukes on same-repository branches only
 
       - name: Enable auto-merge
-        # Merges PR using squash strategy
-
-      - name: Delete branch after merge
-        # Cleans up branches after successful merge
+        # Uses GitHub auto-merge with squash strategy
 ```
 
 ## Setup Requirements
 
-### Personal Access Token (PAT)
+### Token Model
 
-This workflow uses a fine-grained Personal Access Token to bypass branch protection approval requirements,
-enabling full automation for both Dependabot and maintainer PRs.
+The workflow uses `GITHUB_TOKEN` with the narrow permissions needed to read repository contents,
+enable auto-merge, and add the policy note to the pull request.
 
-#### Why a PAT is Needed
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+```
 
-The default `GITHUB_TOKEN` has limitations:
-
-- ❌ Cannot approve PRs created by the same user running the workflow
-- ❌ Cannot bypass branch protection rules requiring approvals
-
-A PAT with appropriate permissions:
-
-- ✅ Can approve PRs from any user (including repository owner)
-- ✅ Can merge PRs that meet branch protection requirements
-- ✅ Enables full automation without manual intervention
-
-#### Creating the PAT
-
-1. **Navigate to GitHub Settings**:
-   - Go to: <https://github.com/settings/personal-access-tokens/new>
-   - Or: Settings → Developer settings → Personal access tokens → Fine-grained tokens
-
-2. **Configure Token Settings**:
-
-   **Token name**: `AUTO_MERGE_TOKEN`
-
-   **Expiration**: `90 days` (recommended - you'll get renewal reminders)
-
-   **Repository access**:
-   - Select: **Only select repositories**
-   - Choose: Your repository (e.g., `tydukes/coding-style-guide`)
-
-   **Permissions** (Repository permissions):
-   - `Contents`: **Read and write**
-   - `Pull requests`: **Read and write**
-   - `Metadata`: **Read-only** (automatically selected)
-
-3. **Generate and Copy Token**:
-   - Click "Generate token"
-   - **Copy the token immediately** (you'll only see it once)
-
-4. **Store as Repository Secret**:
-
-   Using GitHub CLI:
-
-   ```bash
-   # Option 1: Prompted for token
-   gh secret set AUTO_MERGE_TOKEN --repo owner/repo
-
-   # Option 2: Pipe token directly
-   echo "your_token_here" | gh secret set AUTO_MERGE_TOKEN --repo owner/repo
-   ```
-
-   Or via GitHub web UI:
-   - Go to: Repository → Settings → Secrets and variables → Actions
-   - Click "New repository secret"
-   - Name: `AUTO_MERGE_TOKEN`
-   - Value: Paste your token
-   - Click "Add secret"
-
-#### Token Renewal
-
-Fine-grained PATs expire for security. GitHub will email you before expiration:
-
-1. **7 days before**: First reminder
-2. **1 day before**: Final reminder
-3. **On expiration**: Workflow will fail
-
-To renew:
-
-1. Go to: <https://github.com/settings/tokens>
-2. Find `AUTO_MERGE_TOKEN`
-3. Click "Regenerate token"
-4. Update the repository secret with the new value
-
-#### PAT Security Best Practices
-
-- ✅ **Scope**: Limited to specific repository only
-- ✅ **Permissions**: Minimum required (contents + PRs)
-- ✅ **Expiration**: 90-day rotation enforced
-- ✅ **Auditing**: All PAT actions logged in audit log
-- ⚠️ **Storage**: Never commit the token to git
-- ⚠️ **Sharing**: Keep the token secure, don't share it
+Do not add `AUTO_MERGE_TOKEN` for this workflow. A personal access token would make it easier to
+bypass review gates, which is not the intended policy. If a future workflow truly needs a PAT,
+document the exact GitHub limitation, required scopes, expiration, and branch protection impact.
 
 ## How It Works
 
@@ -224,10 +145,10 @@ flowchart TD
     Validate --> ChecksPass
 
     ChecksPass -->|No| End2([Manual Review Required])
-    ChecksPass -->|Yes| Approve[Auto-Approve PR]
+    ChecksPass -->|Yes| Enable[Enable GitHub Auto-Merge]
 
-    Approve --> Merge[Auto-Merge PR]
-    Merge --> Cleanup[Delete Branch]
+    Enable --> Merge[GitHub Merges When All Required Checks Pass]
+    Merge --> Cleanup[Repository Branch Cleanup Policy Applies]
     Cleanup --> End3([✅ Complete])
 ```
 
@@ -235,19 +156,20 @@ flowchart TD
 
 The auto-merge workflow triggers on:
 
-1. **PR Events**: When a PR is opened, synchronized, or reopened
-2. **Review Events**: When a review is submitted
-3. **Check Suite Events**: When CI checks complete
-4. **Status Events**: When commit statuses update
+1. **CI Completion**: The `CI` workflow completes successfully
+2. **Pull Request Source**: The CI run came from a pull request
+3. **Same Repository Branch**: The pull request branch belongs to this repository
 
 ### Merge Criteria
 
-A PR is auto-merged when:
+A PR has auto-merge enabled when:
 
 1. ✅ **Author Check**: PR is from `dependabot[bot]` or `tydukes`
-2. ✅ **CI Checks**: All required checks pass
-3. ✅ **Status Checks**: Combined status is "success"
-4. ✅ **Mergeable State**: No merge conflicts
+2. ✅ **Repository Check**: PR branch is in the same repository, not a fork
+3. ✅ **CI Check**: The `CI` workflow completed successfully
+
+GitHub merges the PR only after branch protection is satisfied. Required checks, required reviews,
+merge conflicts, and repository auto-merge settings still apply.
 
 ## Update Grouping Strategy
 
@@ -308,31 +230,31 @@ Before auto-merge, the following must pass:
 3. **Metadata Validation**: All frontmatter is valid
 4. **No Merge Conflicts**: PR is mergeable
 
-## Maintainer Auto-Merge
+## Maintainer Auto-Merge Enablement
 
-The workflow supports full auto-merge for repository maintainer (@tydukes):
+The workflow supports auto-merge enablement for repository maintainer (@tydukes):
 
 ```yaml
-if: |
-  github.event.pull_request.user.login == 'dependabot[bot]' ||
-  github.event.pull_request.user.login == 'tydukes'
+trusted_auto_merge_authors:
+  - dependabot[bot]
+  - tydukes
 ```
 
 ### How Maintainer Auto-Merge Works
 
-With the `AUTO_MERGE_TOKEN` configured:
+With `GITHUB_TOKEN` permissions configured:
 
-1. ✅ **Auto-Approval**: PAT approves the PR (bypasses self-approval restriction)
-2. ✅ **Branch Protection**: Approval requirement satisfied
-3. ✅ **Auto-Merge**: PR merges automatically when checks pass
-4. ✅ **Branch Cleanup**: Feature branch deleted after merge
+1. ✅ **Eligibility Check**: Workflow confirms trusted author and same-repository branch
+2. ✅ **Auto-Merge Enablement**: GitHub auto-merge is enabled with squash strategy
+3. ✅ **Branch Protection**: Required checks and reviews remain enforced
+4. ✅ **Merge**: GitHub merges when the PR becomes mergeable
 
 ### Benefits for Sole Maintainer
 
-- **Zero Manual Steps**: Create PR → Wait for CI → Automatic merge
+- **Reduced Manual Steps**: Create PR → Wait for CI → GitHub auto-merge enabled
 - **Fast Iteration**: Quick documentation fixes and updates
 - **Consistent Process**: Same workflow for dependencies and feature work
-- **Future-Proof**: Branch protection already in place for future contributors
+- **Future-Proof**: Branch protection remains in place for future contributors
 
 ### Use Cases
 
@@ -384,15 +306,14 @@ gh run view <run-id>
 
 **Issue**: PAT authentication errors
 
-- **Check**: Verify `AUTO_MERGE_TOKEN` secret exists in repository settings
-- **Check**: Ensure PAT hasn't expired (check email notifications)
-- **Solution**: Regenerate PAT and update repository secret
+- **Cause**: The workflow should not use a PAT
+- **Solution**: Remove `AUTO_MERGE_TOKEN` usage and rely on `GITHUB_TOKEN`
 
 **Issue**: "Resource not accessible by integration" error
 
-- **Check**: Verify PAT has `contents: write` and `pull_requests: write` permissions
-- **Check**: Ensure PAT is scoped to the correct repository
-- **Solution**: Recreate PAT with proper permissions
+- **Check**: Verify workflow permissions include `pull-requests: write`
+- **Check**: Verify the PR is not from a fork
+- **Solution**: Use normal maintainer review for outside-contributor PRs
 
 ### GitHub Permissions Required
 
@@ -400,8 +321,9 @@ The auto-merge workflow requires:
 
 ```yaml
 permissions:
-  contents: write        # To merge PRs
-  pull-requests: write   # To approve and manage PRs
+  contents: read         # To read repository metadata
+  pull-requests: write   # To enable GitHub auto-merge
+  issues: write          # To add the auto-merge policy note
 ```
 
 These are granted at the job level in the workflow.
@@ -459,12 +381,12 @@ To add more ecosystems (e.g., npm, cargo):
 Change from squash to merge or rebase:
 
 ```javascript
-merge_method: 'merge'    // Options: merge, squash, rebase
+mergeMethod: 'MERGE'    // Options: MERGE, SQUASH, REBASE
 ```
 
-### Custom Approval Logic
+### Custom Eligibility Logic
 
-Add additional checks before auto-approve:
+Add additional checks before auto-merge enablement:
 
 ```javascript
 // Check changelog for breaking changes
@@ -477,6 +399,7 @@ if (changelog.includes('BREAKING')) {
 ## Related Documentation
 
 - [GitHub Actions Guide](./github_actions_guide.md) - Complete CI/CD patterns
+- [Release Automation](./release_automation.md) - Release, publishing, and recovery policy
 - [GitHub Actions Language Guide](../02_language_guides/github_actions.md) - YAML syntax
 - [Pre-commit Hooks Guide](./precommit_hooks_guide.md) - Local validation
 
@@ -489,4 +412,4 @@ if (changelog.includes('BREAKING')) {
 ---
 
 **Note**: This configuration is designed for a single-maintainer repository with trusted dependency
-sources. Adjust security controls for multi-contributor projects.
+sources. Outside-contributor pull requests follow the normal review and branch protection path.

--- a/docs/05_ci_cd/release_automation.md
+++ b/docs/05_ci_cd/release_automation.md
@@ -1,0 +1,193 @@
+---
+title: "Release and Auto-Merge Automation"
+description: "Repository policy for auto-merge, publishing credentials, trusted workflow refs,
+  and partial-release recovery"
+author: "Tyler Dukes"
+tags: [release, automation, auto-merge, github-actions, publishing, security]
+category: "CI/CD"
+status: "active"
+search_keywords: [release automation, auto merge, github token, npm publishing, container publishing]
+---
+
+## Automation Policy
+
+Automation must help trusted maintainers move faster without changing the repository security model.
+Branch protection, required checks, review rules, and GitHub token restrictions remain the source of
+truth for whether a pull request can merge or a release can publish.
+
+## Auto-Merge Rules
+
+Trusted same-repository pull requests may have GitHub auto-merge enabled after CI succeeds. The
+workflow does not directly approve, directly merge, or delete branches with a personal access token.
+
+```yaml
+trusted_auto_merge_authors:
+  maintainers:
+    - tydukes
+  automation:
+    - dependabot[bot]
+
+required_behavior:
+  merge_method: squash
+  token: GITHUB_TOKEN
+  same_repository_branch: true
+  direct_merge: false
+  auto_approve: false
+  branch_protection_bypass: false
+```
+
+Outside contributors are intentionally excluded from automatic enablement. Their pull requests must
+receive normal maintainer review and pass the required branch protection checks before merge.
+
+```yaml
+outside_contributor_guardrails:
+  forked_pull_requests:
+    auto_merge_enabled_by_workflow: false
+    publish_secrets_available: false
+    maintainer_review_required: true
+  first_time_contributors:
+    secret_bearing_workflows: maintainer_approval_required
+```
+
+## Required Checks
+
+Branch protection should require the checks that represent the full repository risk, not only the
+first workflow that completes.
+
+```yaml
+required_checks:
+  - Commit Message Lint
+  - CI
+  - CLI Build and Test
+  - Dependency Version Check
+  - Spell Checker
+  - CodeQL
+  - SonarCloud
+  - Build and Publish Container
+```
+
+Container checks are required for container-affecting changes. CodeQL and SonarCloud are required
+where those services are enabled for the repository.
+
+## Token Rules
+
+Use `GITHUB_TOKEN` by default. It is scoped to the repository, receives workflow-level permissions,
+and is the correct token for checkout, version bump commits, release creation, issue creation, and
+GitHub auto-merge enablement.
+
+```yaml
+github_token_uses:
+  - actions checkout
+  - release version bump commits
+  - changelog commits
+  - GitHub release creation
+  - GitHub auto-merge enablement
+  - recovery issue creation
+  - ghcr container publishing
+```
+
+Use a personal access token only when GitHub documents a permission limitation that blocks the
+intended operation and the repository intentionally accepts that risk. A personal access token must
+be fine-grained, limited to this repository, time-bound, and documented with the exact reason and
+permissions.
+
+```yaml
+personal_access_token_rules:
+  default: avoid
+  allowed_only_when:
+    - GITHUB_TOKEN cannot perform the required GitHub operation
+    - branch protection is not bypassed
+    - scopes are documented
+    - expiration is configured
+  not_required_for:
+    - current auto-merge workflow
+    - current release workflow
+```
+
+## Release Path
+
+Releases are manual, trusted-ref workflows. Run them from `main`; do not run release publishing from
+pull requests, forks, feature branches, or code that has not been reviewed.
+
+```bash
+gh workflow run release.yml --ref main --field bump_type=patch
+gh workflow run release.yml --ref main --field bump_type=auto
+```
+
+For recovery of a partially completed version, rerun the workflow with the exact version and no
+leading `v`.
+
+```bash
+gh workflow run release.yml --ref main --field release_version=1.2.3
+```
+
+The release path keeps the Python package version, CLI package version, GitHub release tag,
+changelog generation, and npm package publish in one workflow.
+
+```yaml
+release_steps:
+  - validate main branch
+  - validate NPM_TOKEN exists
+  - determine version
+  - update pyproject.toml
+  - update cli/package.json
+  - update cli/package-lock.json
+  - commit version bump
+  - create GitHub release
+  - generate changelog
+  - commit changelog
+  - publish CLI to npm
+```
+
+## Container Publishing
+
+Container images are built for pull requests but only published from release or tag events. The
+`main` branch build validates documentation and code, but it does not publish `latest`.
+
+```yaml
+container_publishing:
+  pull_request:
+    build: true
+    push: false
+    platform: linux/amd64
+  tag_or_release:
+    build: true
+    push: true
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - semver
+      - latest
+```
+
+## Partial Release Recovery
+
+A partial release is any run where one artifact succeeds and a later artifact fails. Examples include
+a GitHub release created but npm publish failed, or an npm package published but container publishing
+failed.
+
+The workflows create recovery issues when a release or release container publish fails on a trusted
+ref. The issue records the intended version, completed steps, failed steps, workflow run, commit, and
+recommended forward-fix path.
+
+```yaml
+recovery_issue_contents:
+  - release version
+  - completed jobs
+  - failed jobs
+  - workflow run URL
+  - commit SHA
+  - same-version recovery command
+```
+
+Prefer completing the same intended version. Do not create a second divergent version unless no
+release artifacts were published.
+
+```text
+1. Inspect the failed workflow job.
+2. Check GitHub releases, npm, and ghcr for artifacts that already exist.
+3. Fix the failed automation or package state on main.
+4. Rerun release.yml with release_version set to the same version.
+5. Manually publish only a missing artifact if a full rerun would duplicate completed work.
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,6 +220,7 @@ nav:
           - Performance Optimization: 05_ci_cd/performance_optimization.md
           - Documentation Versioning: 05_ci_cd/documentation_versioning.md
           - Changelog Automation: 05_ci_cd/changelog_automation_guide.md
+          - Release Automation: 05_ci_cd/release_automation.md
   - Container Usage: 06_container/usage.md
   - Integration:
       - Integration Guide: 07_integration/integration_prompt.md


### PR DESCRIPTION
## Summary

Addresses #447 by hardening the repository automation model around auto-merge, release publishing, container publishing, and partial-release recovery.

## Changes

- Reworked auto-merge to use `GITHUB_TOKEN` and GitHub auto-merge enablement instead of PAT-backed auto-approval and direct merging.
- Added release preflight checks, exact-version recovery support, npm publish state detection, provenance publishing, and automatic release recovery issue creation.
- Changed container publishing to release/tag-based publishing while keeping pull request image builds for validation.
- Documented auto-merge rules, token policy, outside-contributor guardrails, release recovery, and container publishing policy.

## Validation

- `pre-commit run --files AGENTS.md mkdocs.yml .github/workflows/auto-merge.yml .github/workflows/release.yml .github/workflows/container.yml docs/05_ci_cd/dependabot_auto_merge.md docs/05_ci_cd/release_automation.md`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "OK #{p}" }' .github/workflows/auto-merge.yml .github/workflows/release.yml .github/workflows/container.yml mkdocs.yml`
- `uv run mkdocs build --strict`
- `npx --yes cspell --config .github/cspell.json AGENTS.md docs/05_ci_cd/dependabot_auto_merge.md docs/05_ci_cd/release_automation.md`

## Notes

Full-repo cspell still reports pre-existing dictionary entries outside this change set. The changed documentation files pass targeted cspell.