### PR TITLE
[codex] Fix Trivy documentation link

### DIFF
--- a/docs/05_ci_cd/security_scanning_guide.md
+++ b/docs/05_ci_cd/security_scanning_guide.md
@@ -5427,7 +5427,7 @@ We will not pursue legal action against researchers who:
 
 ### Container and Infrastructure Security
 
-- [Trivy Documentation](https://aquasecurity.github.io/trivy/)
+- [Trivy Documentation](https://trivy.dev/)
 - [Checkov Documentation](https://www.checkov.io/1.Welcome/What%20is%20Checkov.html)
 - [tfsec Documentation](https://aquasecurity.github.io/tfsec/)
 - [kube-bench Documentation](https://github.com/aquasecurity/kube-bench)


### PR DESCRIPTION
## Summary

Updates the Trivy documentation reference in the security scanning guide from the retired `aquasecurity.github.io/trivy` URL to the current `trivy.dev` URL.

## Root Cause

Issue #421 was created by the automated link checker after `https://aquasecurity.github.io/trivy/` began returning 404.

## Validation

- `npx --yes markdown-link-check@3.13.7 --config .github/markdown-link-check-config.json docs/05_ci_cd/security_scanning_guide.md`
- Pre-commit hooks run during commit, including `markdownlint`

Closes #421